### PR TITLE
feat: 升级自动备份/恢复防数据丢失 + 修复启用兜底写入脏依赖

### DIFF
--- a/app/src/main/java/com/deepseekharness/app/HarnessController.java
+++ b/app/src/main/java/com/deepseekharness/app/HarnessController.java
@@ -1793,6 +1793,103 @@ public class HarnessController {
         }
     }
 
+    // ================= 升级自动备份 / 恢复（防卸载重装丢数据） =================
+
+    /** 当前 App 的 versionCode；读取失败返回 0 */
+    private int currentVersionCode() {
+        try {
+            return appContext.getPackageManager().getPackageInfo(appContext.getPackageName(), 0).versionCode;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    /**
+     * 升级/首次启动自愈（幂等）：版本号比上次运行时提升 → 后台自动把旧环境
+     * （.dsh 配置+对话记录 + .env）备份到外部 Download/DSHA，
+     * 避免后续覆盖安装/卸载重装导致数据丢失。
+     * @return true = 本次为升级或首次启动（调用方可据此检测"全新环境可恢复"）
+     */
+    public boolean upgradeGuard() {
+        final int cur = currentVersionCode();
+        if (cur <= 0) return false;
+        final SharedPreferences prefs =
+                appContext.getSharedPreferences("deepseekharness", android.content.Context.MODE_PRIVATE);
+        final int last = prefs.getInt("last_version_code", 0);
+        if (cur <= last) return false; // 版本未变，幂等返回
+        prefs.edit().putInt("last_version_code", cur).apply();
+        if (last > 0) { // 真升级（非全新安装）：后台自动备份旧环境
+            IO.execute(() -> {
+                try {
+                    if (rootfsFile("root/.dsh").isDirectory()) {
+                        String p = BackupManager.backupToExternal(appContext, HarnessController.this);
+                        if (p != null) android.util.Log.i("DSHA", "升级自动备份完成: " + p);
+                    }
+                } catch (Throwable ignored) {
+                }
+            });
+        }
+        return true;
+    }
+
+    /** 外部下载目录 Download/DSHA 里最新的 DSHA 备份；没有返回 null */
+    public File findLatestExternalBackup() {
+        try {
+            File dir = new File(android.os.Environment.getExternalStoragePublicDirectory(
+                    android.os.Environment.DIRECTORY_DOWNLOADS), "DSHA");
+            File[] fs = dir.listFiles((d, n) -> n.startsWith("DSHA-backup-") && n.endsWith(".tar.gz"));
+            if (fs == null || fs.length == 0) return null;
+            File best = null;
+            for (File f : fs) {
+                if (best == null || f.lastModified() > best.lastModified()) best = f;
+            }
+            return best;
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    /** 从外部备份 tar.gz 恢复 .dsh + .env 到 rootfs；返回结果文案 */
+    public String restoreFromBackup(File backup) {
+        try {
+            File tmp = rootfsFile("root/.dsha-restore.tar.gz");
+            copyFile(backup, tmp);
+            TarGzipExtractor.extract(tmp, new File(proot.getRootfsDir(), "root"));
+            //noinspection ResultOfMethodCallIgnored
+            tmp.delete();
+            return "恢复完成（配置 + 对话记录），重启 WebUI 生效";
+        } catch (Exception e) {
+            return "恢复失败: " + e.getMessage();
+        }
+    }
+
+    /**
+     * 全新环境检测：若 rootfs 尚无数据（卸载重装后的空环境）且 Download/DSHA 存在旧备份，
+     * 弹窗询问是否恢复。仅在 App 升级/首次启动时由调用方触发。
+     */
+    public void maybePromptRestore(final android.app.Activity act) {
+        IO.execute(() -> {
+            try {
+                if (rootfsFile("root/.dsh").isDirectory()) return; // 已有数据，不打扰
+                final File b = findLatestExternalBackup();
+                if (b == null) return;
+                new Handler(Looper.getMainLooper()).post(() -> {
+                    new android.app.AlertDialog.Builder(act)
+                            .setTitle("检测到旧版备份")
+                            .setMessage("发现备份：\n" + b.getName()
+                                    + "\n\n是否恢复到当前环境？\n（恢复配置、API Key 与对话记录）")
+                            .setPositiveButton("恢复", (d, w) -> {
+                                String r = restoreFromBackup(b);
+                                android.widget.Toast.makeText(act, r, android.widget.Toast.LENGTH_LONG).show();
+                            })
+                            .setNegativeButton("忽略", null)
+                            .show();
+                });
+            } catch (Throwable ignored) {
+            }
+        });
+    }
+
     /** 重置配置：删除 settings.yaml + .env（保留对话记录），并重写 .env。 */
     public String resetConfig() {
         try {
@@ -2119,7 +2216,7 @@ public class HarnessController {
                 "const p=JSON.parse(fs.readFileSync(pkg,'utf-8'));\n" +
                 "if(!p.dependencies)p.dependencies={};\n" +
                 "if(mode==='on'){\n" +
-                "  p.dependencies[pn]=src;\n" +
+                "  if(src&&src!=='null'&&src!=='*')p.dependencies[pn]=src;\n" +
                 "  if(p.dsh&&p.dsh.profile&&Array.isArray(p.dsh.profile.bundles)&&p.dsh.profile.bundles.indexOf(pn)<0)p.dsh.profile.bundles.push(pn);\n" +
                 "}else{\n" +
                 "  if(p.dependencies[pn])fs.writeFileSync('/root/.dsh/profiles/web/.dsha-src-'+pn,String(p.dependencies[pn]));\n" +

--- a/app/src/main/java/com/deepseekharness/app/MainActivity.java
+++ b/app/src/main/java/com/deepseekharness/app/MainActivity.java
@@ -68,6 +68,11 @@ public class MainActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_main);
 
+        // 升级/首次启动自愈：自动备份旧环境；全新环境且 Download/DSHA 有旧备份时提示恢复
+        if (HarnessController.get(this).upgradeGuard()) {
+            HarnessController.get(this).maybePromptRestore(this);
+        }
+
         requestPermissions();
         requestBatteryOptimization();
         maybeShowBackupReminder();


### PR DESCRIPTION
## 问题背景
1. **覆盖安装/卸载重装丢数据**：全部数据（.dsh 配置、API Key、对话记录）存在 App 私有目录（files/linux/ubuntu），卸载重装即全部丢失。目前只有手动备份（设置页按钮），升级/换机场景无任何保护。
2. **启用插件的兜底值污染 package.json**：`togglePlugin` 对源记录缺失的插件兜底 `src="*"`，但 `toggleScript` 无条件 `p.dependencies[pn]=src`，会把 `"*"` 写进 dependencies——插件名若不是 npm 包名，后续 pnpm install 会尝试解析该包并失败。

## 改动内容
### `HarnessController.java`
- **`toggleScript()`**：on 分支改为 `if(src&&src!=='null'&&src!=='*')p.dependencies[pn]=src;`——空值/`"null"`/兜底 `"*"` 不再写入 dependencies，仅恢复 bundles + 目录（包体在磁盘上即可加载）。
- **`upgradeGuard()`**（新增）：App 启动时检测 versionCode 提升（幂等，SharedPreferences `last_version_code`）→ 后台自动把旧环境（`.dsh` + `.env`）备份到外部 `Download/DSHA/`，防覆盖安装丢数据。
- **`findLatestExternalBackup()`**（新增）：定位 `Download/DSHA/DSHA-backup-*.tar.gz` 最新一份。
- **`restoreFromBackup(File)`**（新增）：用 `TarGzipExtractor` 把备份解压回 rootfs（`.dsh` + `<workdir>/.env`）。
- **`maybePromptRestore(Activity)`**（新增）：rootfs 无数据（卸载重装后的全新环境）且存在外部旧备份时，弹窗询问是否恢复。

### `MainActivity.java`
- `onCreate` 接入：`upgradeGuard()` + `maybePromptRestore(this)`（升级自动备份；全新环境可恢复提示）。

## 验证情况
- 逻辑经逐行 review，与现有 `BackupManager`（备份格式 `tar -czf .dsha-backup.tar.gz .dsh <wd>/.env`）格式匹配，`TarGzipExtractor` 可直接解压。
- ⚠️ 本环境无 Android SDK，未实际编译运行；请在本地 `./gradlew :app:assembleDebug` 验证后合入。

## 建议后续
- 恢复流程目前是"手动确认弹窗"；后续可做成"升级前自动备份 + 新装引导页一键恢复"的完整迁移向导。