### PR TITLE
fix: PR#11 补丁——rootfs 未就绪保护 + 首启不误弹恢复框

### DIFF
--- a/app/src/main/java/com/deepseekharness/app/HarnessController.java
+++ b/app/src/main/java/com/deepseekharness/app/HarnessController.java
@@ -1821,7 +1821,8 @@ public class HarnessController {
         if (last > 0) { // 真升级（非全新安装）：后台自动备份旧环境
             IO.execute(() -> {
                 try {
-                    if (rootfsFile("root/.dsh").isDirectory()) {
+                    // rootfs 已就绪（有 bash）才备份；未解压/未安装时跳过
+                    if (proot.isInstalled() && rootfsFile("root/.dsh").isDirectory()) {
                         String p = BackupManager.backupToExternal(appContext, HarnessController.this);
                         if (p != null) android.util.Log.i("DSHA", "升级自动备份完成: " + p);
                     }
@@ -1852,6 +1853,7 @@ public class HarnessController {
     /** 从外部备份 tar.gz 恢复 .dsh + .env 到 rootfs；返回结果文案 */
     public String restoreFromBackup(File backup) {
         try {
+            if (!proot.isInstalled()) return "环境未就绪，请先完成环境解压/安装后再恢复";
             File tmp = rootfsFile("root/.dsha-restore.tar.gz");
             copyFile(backup, tmp);
             TarGzipExtractor.extract(tmp, new File(proot.getRootfsDir(), "root"));
@@ -1870,6 +1872,7 @@ public class HarnessController {
     public void maybePromptRestore(final android.app.Activity act) {
         IO.execute(() -> {
             try {
+                if (!proot.isInstalled()) return; // rootfs 未就绪（未解压/未安装）不弹
                 if (rootfsFile("root/.dsh").isDirectory()) return; // 已有数据，不打扰
                 final File b = findLatestExternalBackup();
                 if (b == null) return;

--- a/app/src/main/java/com/deepseekharness/app/MainActivity.java
+++ b/app/src/main/java/com/deepseekharness/app/MainActivity.java
@@ -70,7 +70,11 @@ public class MainActivity extends AppCompatActivity {
 
         // 升级/首次启动自愈：自动备份旧环境；全新环境且 Download/DSHA 有旧备份时提示恢复
         if (HarnessController.get(this).upgradeGuard()) {
-            HarnessController.get(this).maybePromptRestore(this);
+            // 仅解压完成进入主界面（skip_extract=true）才检测"全新环境可恢复"，
+            // 避免首启解压前 rootfs 未就绪误弹恢复框（恢复内容会被解压流程覆盖）
+            if (getIntent().getBooleanExtra("skip_extract", false)) {
+                HarnessController.get(this).maybePromptRestore(this);
+            }
         }
 
         requestPermissions();


### PR DESCRIPTION
## 背景
PR#11（自动备份/恢复）作者未编译验证，审查发现 3 处问题：

1. **maybePromptRestore 首启误弹**：全内置 APK 首启时 MainActivity.onCreate 在解压流程之前执行，rootfs 尚未解压 → `root/.dsh` 不存在 → 误判为"全新环境"弹恢复框，且此时恢复的内容会被随后的解压流程覆盖。
2. **restoreFromBackup 无保护**：rootfs 未就绪时解压恢复会失败/路径错。
3. **upgradeGuard 备份误判**：rootfs 未就绪时 .dsh 目录不存在，备份判断不可靠。

## 修复
- `maybePromptRestore` / `restoreFromBackup`：加 `proot.isInstalled()` 保护
- `upgradeGuard`：备份条件加 `proot.isInstalled()`
- `MainActivity`：仅 `skip_extract=true`（解压完成进入主界面）才触发恢复检测

## 验证
- 本地 `gradle :app:compileDebugJavaWithJavac` 编译通过 ✅
- 已在本环境构建 APK 验证