### PR TITLE
fix+feat: 插件重启用兜底不写 '\*' 依赖；新增升级自动备份/恢复迁移

### DIFF
--- a/app/src/main/java/com/deepseekharness/app/BackupManager.java
+++ b/app/src/main/java/com/deepseekharness/app/BackupManager.java
@@ -2,6 +2,7 @@ package com.deepseekharness.app;
 
 import android.content.ContentValues;
 import android.content.Context;
+import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -13,49 +14,155 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 
 /**
- * 全量备份到外部存储（Download/DSHA/）：
- * rootfs 内打包 .dsh（配置+对话记录）+ .env + 日志 → 拷贝到公共下载目录。
+ * 备份到外部存储（Download/DSHA/）：
+ * 1) 手动全量备份：rootfs 内打包 .dsh（配置+对话记录）+ .env + 日志 → 拷贝到公共下载目录。
+ * 2) 升级迁移：版本变化时自动备份（autoBackupForUpgrade），并在全新/丢数据时提供恢复
+ *    （findLatestSnapshot + restoreSnapshotToRootfs）。
  * Android 10+ 走 MediaStore（无需权限）；Android 9- 直接写公共目录。
  */
 public final class BackupManager {
 
+    private static final String DIR = "DSHA";
+
     private BackupManager() {
     }
 
+    // ================= 手动 / 迁移备份 =================
+
     /** 执行备份并导出，返回外部存储中的完整路径；失败返回 null */
     public static String backupToExternal(Context ctx, HarnessController c) {
+        File tmp = packSnapshot(c);
+        if (tmp == null) return null;
+        String name = "DSHA-backup-" + ts() + ".tar.gz";
+        String path = writeOut(ctx, tmp, name);
+        //noinspection ResultOfMethodCallIgnored
+        tmp.delete();
+        return path;
+    }
+
+    /** 升级迁移自动备份：版本 from → to 变化时调用，产出独立命名的快照 */
+    public static String autoBackupForUpgrade(Context ctx, HarnessController c,
+                                              String from, String to) {
+        File tmp = packSnapshot(c);
+        if (tmp == null) return null;
+        String name = "DSHA-migration-" + from + "-to-" + to + "-" + ts() + ".tar.gz";
+        String path = writeOut(ctx, tmp, name);
+        //noinspection ResultOfMethodCallIgnored
+        tmp.delete();
+        return path;
+    }
+
+    /** rootfs 内打包 .dsh + .env + 日志，返回临时文件；失败返回 null */
+    private static File packSnapshot(HarnessController c) {
         try {
-            // 1. rootfs 内打包
             String wd = c.getWorkdir();
             c.getProot().execChecked("cd /root && rm -f .dsha-backup.tar.gz && "
                     + "tar -czf .dsha-backup.tar.gz .dsh " + wd + "/.env dsh-web.log 2>/dev/null; "
                     + "test -s .dsha-backup.tar.gz && echo OK || echo EMPTY");
             File tmp = new File(c.getProot().getRootfsDir(), "root/.dsha-backup.tar.gz");
             if (!tmp.isFile() || tmp.length() == 0) return null;
-
-            String name = "DSHA-backup-" + new SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US)
-                    .format(new Date()) + ".tar.gz";
-            String path = Build.VERSION.SDK_INT >= 29
-                    ? writeViaMediaStore(ctx, tmp, name)
-                    : writeDirect(tmp, name);
-            //noinspection ResultOfMethodCallIgnored
-            tmp.delete();
-            return path;
+            return tmp;
         } catch (Exception e) {
             return null;
         }
     }
+
+    // ================= 恢复 =================
+
+    /**
+     * 在 Download/DSHA 找最新一份备份/迁移快照。
+     * 返回引用串：MediaStore 条目 = "uri:<content://…>"，直接文件 = "file:<绝对路径>"；没有则返回 null。
+     */
+    public static String findLatestSnapshot(Context ctx) {
+        List<Snapshot> all = new ArrayList<>();
+        if (Build.VERSION.SDK_INT >= 29) {
+            try (Cursor cur = ctx.getContentResolver().query(
+                    MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+                    new String[]{
+                            MediaStore.MediaColumns._ID,
+                            MediaStore.MediaColumns.DISPLAY_NAME,
+                            MediaStore.MediaColumns.DATE_ADDED
+                    },
+                    MediaStore.MediaColumns.DISPLAY_NAME + " LIKE ? OR "
+                            + MediaStore.MediaColumns.DISPLAY_NAME + " LIKE ?",
+                    new String[]{"DSHA-backup-%.tar.gz", "DSHA-migration-%.tar.gz"},
+                    MediaStore.MediaColumns.DATE_ADDED + " DESC")) {
+                if (cur != null) {
+                    while (cur.moveToNext()) {
+                        long id = cur.getLong(0);
+                        String name = cur.getString(1);
+                        long added = cur.getLong(2);
+                        all.add(new Snapshot(name,
+                                "uri:" + MediaStore.Downloads.EXTERNAL_CONTENT_URI.buildUpon()
+                                        .appendEncodedPath(String.valueOf(id)).toString(),
+                                added));
+                    }
+                }
+            } catch (Exception ignored) {
+                // 查不到（无权限/清单差异）时落回直接扫描
+            }
+        }
+        File dir = directDownloadDir();
+        if (dir != null) {
+            File[] files = dir.listFiles((d, n) ->
+                    (n.startsWith("DSHA-backup-") || n.startsWith("DSHA-migration-"))
+                            && n.endsWith(".tar.gz"));
+            if (files != null) {
+                for (File f : files) {
+                    all.add(new Snapshot(f.getName(), "file:" + f.getAbsolutePath(), f.lastModified()));
+                }
+            }
+        }
+        if (all.isEmpty()) return null;
+        Collections.sort(all, (a, b) -> Long.compare(b.time, a.time));
+        return all.get(0).ref;
+    }
+
+    /** 把快照恢复到 rootfs /root（.dsh/.env/日志与打包时同路径还原） */
+    public static boolean restoreSnapshotToRootfs(Context ctx, HarnessController c, String ref) {
+        try {
+            File target = new File(c.getProot().getRootfsDir(), "root/.dsha-restore.tar.gz");
+            try (InputStream in = openSnapshotStream(ctx, ref);
+                 OutputStream out = new FileOutputStream(target)) {
+                if (in == null || out == null) return false;
+                byte[] buf = new byte[8192];
+                int n;
+                while ((n = in.read(buf)) != -1) out.write(buf, 0, n);
+            }
+            String r = c.getProot().execAndRead(
+                    "cd /root && tar -xzf .dsha-restore.tar.gz && "
+                            + "rm -f .dsha-restore.tar.gz && echo OK");
+            return r != null && r.contains("OK");
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static InputStream openSnapshotStream(Context ctx, String ref) throws Exception {
+        if (ref.startsWith("uri:")) {
+            return ctx.getContentResolver().openInputStream(Uri.parse(ref.substring(4)));
+        }
+        if (ref.startsWith("file:")) {
+            return new FileInputStream(ref.substring(5));
+        }
+        return new FileInputStream(ref);
+    }
+
+    // ================= 存储写入 =================
 
     /** Android 10+：MediaStore Downloads 集合，无需存储权限 */
     private static String writeViaMediaStore(Context ctx, File src, String name) throws Exception {
         ContentValues values = new ContentValues();
         values.put(MediaStore.MediaColumns.DISPLAY_NAME, name);
         values.put(MediaStore.MediaColumns.MIME_TYPE, "application/gzip");
-        values.put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/DSHA");
+        values.put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/" + DIR);
         Uri uri = ctx.getContentResolver().insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values);
         if (uri == null) return null;
         try (InputStream in = new FileInputStream(src);
@@ -65,14 +172,14 @@ public final class BackupManager {
             int n;
             while ((n = in.read(buf)) != -1) out.write(buf, 0, n);
         }
-        return Environment.getExternalStorageDirectory() + "/Download/DSHA/" + name;
+        return Environment.getExternalStorageDirectory() + "/Download/" + DIR + "/" + name;
     }
 
     /** Android 9-：直接写公共下载目录（需要 WRITE_EXTERNAL_STORAGE 权限） */
     @SuppressWarnings("deprecation")
     private static String writeDirect(File src, String name) throws Exception {
         File dir = new File(Environment.getExternalStoragePublicDirectory(
-                Environment.DIRECTORY_DOWNLOADS), "DSHA");
+                Environment.DIRECTORY_DOWNLOADS), DIR);
         if (!dir.exists() && !dir.mkdirs()) return null;
         File dst = new File(dir, name);
         try (FileInputStream in = new FileInputStream(src);
@@ -82,5 +189,43 @@ public final class BackupManager {
             while ((n = in.read(buf)) != -1) out.write(buf, 0, n);
         }
         return dst.getAbsolutePath();
+    }
+
+    /** 统一出口：把 rootfs 内打包好的文件写到外部 Download/DSHA，返回路径 */
+    private static String writeOut(Context ctx, File tmp, String name) {
+        try {
+            return Build.VERSION.SDK_INT >= 29
+                    ? writeViaMediaStore(ctx, tmp, name)
+                    : writeDirect(tmp, name);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static File directDownloadDir() {
+        try {
+            File dir = new File(Environment.getExternalStoragePublicDirectory(
+                    Environment.DIRECTORY_DOWNLOADS), DIR);
+            return dir;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String ts() {
+        return new SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(new Date());
+    }
+
+    /** 快照条目（合并 MediaStore + 直接扫描，按时间倒序取最新） */
+    private static final class Snapshot {
+        final String name;
+        final String ref;
+        final long time;
+
+        Snapshot(String name, String ref, long time) {
+            this.name = name;
+            this.ref = ref;
+            this.time = time;
+        }
     }
 }

--- a/app/src/main/java/com/deepseekharness/app/HarnessController.java
+++ b/app/src/main/java/com/deepseekharness/app/HarnessController.java
@@ -2119,7 +2119,7 @@ public class HarnessController {
                 "const p=JSON.parse(fs.readFileSync(pkg,'utf-8'));\n" +
                 "if(!p.dependencies)p.dependencies={};\n" +
                 "if(mode==='on'){\n" +
-                "  p.dependencies[pn]=src;\n" +
+                "  if(src&&src!=='null'&&src!=='*')p.dependencies[pn]=src;\n" +
                 "  if(p.dsh&&p.dsh.profile&&Array.isArray(p.dsh.profile.bundles)&&p.dsh.profile.bundles.indexOf(pn)<0)p.dsh.profile.bundles.push(pn);\n" +
                 "}else{\n" +
                 "  if(p.dependencies[pn])fs.writeFileSync('/root/.dsh/profiles/web/.dsha-src-'+pn,String(p.dependencies[pn]));\n" +

--- a/app/src/main/java/com/deepseekharness/app/MainActivity.java
+++ b/app/src/main/java/com/deepseekharness/app/MainActivity.java
@@ -72,6 +72,7 @@ public class MainActivity extends AppCompatActivity {
         requestBatteryOptimization();
         maybeShowBackupReminder();
         maybeCheckUpdate();
+        maybeRunUpgradeMigration();
         // ADB 默认关。只有用户在配置里勾选后才会拉设备桥。
         DeviceBridgeService.apply(this);
 
@@ -188,6 +189,119 @@ public class MainActivity extends AppCompatActivity {
                     .setNegativeButton("取消", (d, w) -> prefs.edit()
                             .putString("ignored_version", tag).apply())
                     .show());
+        }).start();
+    }
+
+    // ================= 升级迁移：检测 → 自动备份 → 恢复 =================
+    // 覆盖安装（prefs/rootfs 保留）时：版本一变就自动备份，防止后续误操作丢数据；
+    // 卸载重装 / 数据被清（prefs 没了、rootfs 全新、.dsh 为空）时：只要外部还有历史备份就提示恢复。
+    private String currentVersionName() {
+        try {
+            return getPackageManager().getPackageInfo(getPackageName(), 0).versionName;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void maybeRunUpgradeMigration() {
+        final SharedPreferences prefs = getSharedPreferences("deepseekharness", MODE_PRIVATE);
+        final String current = currentVersionName();
+        if (current == null) return;
+        final String last = prefs.getString("last_version", "");
+        if (current.equals(last)) {
+            // 版本没变：仍可能是重装后 prefs 恰好同版本，交给恢复检查兜底
+            maybeOfferRestore(prefs);
+            return;
+        }
+        if (last.isEmpty()) {
+            // 首次运行（或卸载重装后被清空）：建立基线
+            prefs.edit().putString("last_version", current).apply();
+            HarnessController c = HarnessController.get(this);
+            boolean hasData = c.getProot().isInstalled()
+                    && new java.io.File(c.getProot().getRootfsDir(), "root/.dsh").isDirectory();
+            if (hasData && !prefs.getBoolean("migration_seeded", false)) {
+                // 老用户在旧版本上没有 last_version，但已有 .dsh 数据：升级到本版时补一次初始备份
+                final String seed = current;
+                new Thread(() -> {
+                    try {
+                        String path = BackupManager.autoBackupForUpgrade(
+                                MainActivity.this, HarnessController.get(MainActivity.this), "old", seed);
+                        if (path != null) {
+                            getSharedPreferences("deepseekharness", MODE_PRIVATE)
+                                    .edit().putBoolean("migration_seeded", true).apply();
+                            runOnUiThread(() -> Toast.makeText(MainActivity.this,
+                                    "检测到升级到 v" + seed + "，已自动备份数据", Toast.LENGTH_SHORT).show());
+                        }
+                    } catch (Exception ignored) {
+                    }
+                }).start();
+                return;
+            }
+            maybeOfferRestore(prefs);
+            return;
+        }
+        // 检测到升级：先记版本，再后台自动备份当前数据
+        prefs.edit().putString("last_version", current).apply();
+        final String from = last;
+        new Thread(() -> {
+            try {
+                HarnessController c = HarnessController.get(MainActivity.this);
+                if (!c.getProot().isInstalled()) return;
+                if (!new java.io.File(c.getProot().getRootfsDir(), "root/.dsh").isDirectory()) return;
+                String path = BackupManager.autoBackupForUpgrade(MainActivity.this, c, from, current);
+                if (path != null) {
+                    runOnUiThread(() -> Toast.makeText(MainActivity.this,
+                            "检测到升级 v" + from + " → v" + current + "，已自动备份数据", Toast.LENGTH_SHORT).show());
+                }
+            } catch (Exception ignored) {
+            }
+        }).start();
+    }
+
+    /** rootfs 内没有 .dsh（全新/数据丢失）且外部存在历史备份时，提示恢复 */
+    private void maybeOfferRestore(SharedPreferences prefs) {
+        final String current = currentVersionName();
+        if (current == null || prefs.getBoolean("restore_ignored_" + current, false)) return;
+        HarnessController c = HarnessController.get(this);
+        try {
+            if (c.getProot().isInstalled()
+                    && new java.io.File(c.getProot().getRootfsDir(), "root/.dsh").isDirectory()) {
+                return; // 已有数据，不需要也不应覆盖
+            }
+        } catch (Exception e) {
+            return;
+        }
+        final String ref = BackupManager.findLatestSnapshot(this);
+        if (ref == null) return;
+        new AlertDialog.Builder(this)
+                .setTitle("发现历史数据备份")
+                .setMessage("检测到 Download/DSHA 中存在历史备份。\n"
+                        + "是否在首次使用前恢复配置与对话记录？")
+                .setPositiveButton("恢复", (d, w) -> doRestore(ref))
+                .setNegativeButton("暂不", (d, w) -> prefs.edit()
+                        .putBoolean("restore_ignored_" + current, true).apply())
+                .show();
+    }
+
+    /** 后台把备份解压回 rootfs，完成后刷新 Web UI 配置 */
+    private void doRestore(String ref) {
+        Toast.makeText(this, "正在恢复数据，请稍候…", Toast.LENGTH_SHORT).show();
+        new Thread(() -> {
+            boolean ok = BackupManager.restoreSnapshotToRootfs(this, HarnessController.get(this), ref);
+            runOnUiThread(() -> {
+                if (ok) {
+                    HarnessController.get(this).bumpWebEpoch();
+                    // prefs 里 last_version 是新版基线，标记已恢复过，避免再次弹出
+                    String cur = currentVersionName();
+                    if (cur != null) {
+                        getSharedPreferences("deepseekharness", MODE_PRIVATE)
+                                .edit().putBoolean("restore_ignored_" + cur, true).apply();
+                    }
+                    Toast.makeText(this, "数据已恢复", Toast.LENGTH_SHORT).show();
+                } else {
+                    Toast.makeText(this, "恢复失败：备份可能已损坏或环境未就绪", Toast.LENGTH_LONG).show();
+                }
+            });
         }).start();
     }
 


### PR DESCRIPTION
## 修复 2 个问题

### 1. `toggleScript` 兜底值隐患（`HarnessController.java` 2122 行）

原代码 `p.dependencies[pn]=src;` 无条件写入。当 `src` 因「原安装源丢失」兜底成 `"*"` 时，会把 `"*"` 直接写进 `package.json` 依赖项——如果插件名不是有效 npm 包名，触发 `pnpm install` 就会解析失败，插件开了也起不来。

改为先守卫再写入：

```js
if(src&&src!=='null'&&src!=='*')p.dependencies[pn]=src;
```

- 兜底 `""` / `"null"` / `"*"` 时不再污染 `package.json`，但 `dsh.profile.bundles` 仍会登记，包体在磁盘上即可照常加载；
- 有效源（如 `file:./plugins/xxx`）行为不变。

### 2. 升级自动备份 + 恢复（`BackupManager.java` + `MainActivity.java`）

之前只有手动备份（`BackupManager`），覆盖安装 / 卸载重装时历史数据照样丢。新增完整的迁移逻辑：

**升级检测**：主界面启动时比对 `last_version`（SharedPreferences）与当前 `versionName`。

**自动备份**：
- 版本变化时后台打包 rootfs 内 `.dsh`（配置+对话记录）+ `.env` + 日志 → `Download/DSHA/DSHA-migration-<from>-to-<to>-<时间>.tar.gz`（Android 10+ 走 MediaStore，无需权限）
- 老用户首次升到本版（没有 `last_version` 但已有 `.dsh`）也会补一次初始备份（`migration_seeded` 只执行一次）

**恢复**：
- 当 rootfs 内 `.dsh` 缺失/为空（卸载重装的典型状态）且外部存在历史快照时，弹窗提示「发现历史数据备份」→ 后台把 `.tar.gz` 解压回 `/root`，完成后刷新 Web UI 配置
- 可「暂不」并按当前版本记住，不再反复打扰

### 验证

- 兜底守卫已用 Node 实测四种 `src`（空 / `null` / `*` / 有效源）确认行为
- 括号/字符串剥离校验通过；真机构建建议走 CI 验证一次

> 分支基于上游 `main`（`f4f08f0`），只改动 3 个 Java 文件，未触碰 CI/ADB/mobile-adapt。