### PR TITLE
docs: README 顶部加 agent 先读 AGENTS.md 的提示

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DSHA
 
+> 🤖 Agent / AI 开发者请先读 [AGENTS.md](AGENTS.md)（英文，概述项目结构、启动契约与约定）。
+
 **DeepSeek Harness 安卓启动器** —— 在手机上跑 deepseek-harness 的一体化方案，无需 Termux、无需 ROOT。
 
 内置 proot + Ubuntu rootfs，一键（或分步）安装 deepseek-harness，内嵌 WebView 直接使用 Web UI。


### PR DESCRIPTION
README 顶部加一行提示，让 Agent/AI 开发者先读 AGENTS.md（英文总览），避免直接扫全库。仅改 README.md 一处。