### PR TITLE
fix: 插件页「重启 WebUI」1.5s 延迟回调可致闪退

### DIFF
--- a/app/src/main/java/com/deepseekharness/app/PluginFragment.java
+++ b/app/src/main/java/com/deepseekharness/app/PluginFragment.java
@@ -517,17 +517,20 @@ public class PluginFragment extends Fragment {
                 .setTitle((ok ? "✅ 安装成功：" : "❌ 安装失败：") + display)
                 .setMessage(out == null ? "无输出" : out)
                 .setPositiveButton("重启 WebUI", (d, w) -> {
-                    android.content.Intent stop = new android.content.Intent(requireContext(), HarnessService.class)
+                    // 1.5s 延迟回调期间用户可能已离开本页：全程用 applicationContext，
+                    // 不能在回调里再 requireContext()（fragment detach 后必抛异常闪退）
+                    final android.content.Context app = requireContext().getApplicationContext();
+                    android.content.Intent stop = new android.content.Intent(app, HarnessService.class)
                             .setAction(HarnessService.ACTION_STOP);
-                    requireContext().startService(stop);
+                    app.startService(stop);
                     new android.os.Handler(android.os.Looper.getMainLooper()).postDelayed(() -> {
-                        android.content.Intent i = new android.content.Intent(requireContext(), HarnessService.class);
+                        android.content.Intent i = new android.content.Intent(app, HarnessService.class);
                         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-                            requireContext().startForegroundService(i);
+                            app.startForegroundService(i);
                         } else {
-                            requireContext().startService(i);
+                            app.startService(i);
                         }
-                        status.setText("WebUI 已重启");
+                        if (isAdded()) status.setText("WebUI 已重启");
                     }, 1500);
                 })
                 .setNegativeButton("关闭", null)
@@ -545,17 +548,19 @@ public class PluginFragment extends Fragment {
                         .setTitle("安装完成")
                         .setMessage(out == null ? "无输出" : out)
                         .setPositiveButton("重启 WebUI", (d, w) -> {
-                            android.content.Intent stop = new android.content.Intent(requireContext(), HarnessService.class)
+                            // 同 showInstallResult：延迟回调用 applicationContext，防 detach 后闪退
+                            final android.content.Context app = requireContext().getApplicationContext();
+                            android.content.Intent stop = new android.content.Intent(app, HarnessService.class)
                                     .setAction(HarnessService.ACTION_STOP);
-                            requireContext().startService(stop);
+                            app.startService(stop);
                             new android.os.Handler(android.os.Looper.getMainLooper()).postDelayed(() -> {
-                                android.content.Intent i = new android.content.Intent(requireContext(), HarnessService.class);
+                                android.content.Intent i = new android.content.Intent(app, HarnessService.class);
                                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-                                    requireContext().startForegroundService(i);
+                                    app.startForegroundService(i);
                                 } else {
-                                    requireContext().startService(i);
+                                    app.startService(i);
                                 }
-                                Toast.makeText(requireContext(), "正在重启 Web UI…", Toast.LENGTH_SHORT).show();
+                                android.widget.Toast.makeText(app, "正在重启 Web UI…", Toast.LENGTH_SHORT).show();
                             }, 1500);
                         })
                         .setNegativeButton("关闭", null)


### PR DESCRIPTION
showInstallResult / doInstall 的重启按钮：先发 ACTION_STOP， postDelayed 1500ms 后再拉起服务。延迟回调里调用了
requireContext()——用户在这 1.5 秒内切页/返回（fragment detach） 就抛 IllegalStateException 直接闪退。

改为点击时即捕获 applicationContext，回调全程用它；status 文案
更新前判 isAdded()。重启链路本身不变：stopWeb 虽是异步 pkill，
但 startWeb 自带端口预检+深杀（EADDRINUSE 防护），1.5s 间隔安全。

重启机制其余四层（强重启/保活/看门狗/startWeb 并发锁）检查
无问题，未改动。