### PR TITLE
fix: 修复老 WebView AbortSignal.any 与外部浏览器 /api 403

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bundle/offline-rootfs.tar.gz
-          key: offline-rootfs-${{ hashFiles('scripts/offline-provision.sh', 'scripts/ci-make-offline-bundle.sh', 'app/src/main/assets/rootfs-confirm-install.sh', 'app/src/main/assets/webui-polyfill.sh', 'app/src/main/assets/*.patch') }}
+          key: offline-rootfs-${{ hashFiles('scripts/offline-provision.sh', 'scripts/ci-make-offline-bundle.sh', 'app/src/main/assets/rootfs-confirm-install.sh', 'app/src/main/assets/webui-polyfill.sh', 'app/src/main/assets/webui-origin-port-patch.sh', 'app/src/main/assets/*.patch') }}
 
       - name: Build offline rootfs bundle
         if: steps.cache.outputs.cache-hit != 'true'

--- a/app/src/main/assets/webui-origin-port-patch.sh
+++ b/app/src/main/assets/webui-origin-port-patch.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# webui-origin-port-patch.sh — 修复外部浏览器（Chrome 150+）访问 127.0.0.1:3080 时
+# 所有 /api 请求 403 的问题。
+#
+# 根因：dsh-client-connection 的 isTrustedApiRequest 在校验 Origin 时
+#   用 new URL(origin).host === hostUrl.host 比较。Chrome 150+ 对 loopback
+#   同源请求发送的 Origin 会省略端口（http://127.0.0.1），而 Host 是
+#   127.0.0.1:3080，导致 host 比较失败 -> /api 全部 403 -> 前端表现为
+#   “无法连接网络”。App 内置 WebView（旧版 Chromium）不受影响。
+#
+# 修复：改为比较 hostname（端口不是 CSRF / DNS-rebinding 边界）。
+# 幂等：已改则跳过；LAN 补丁已把函数改为 return true 时同样跳过。
+set -u
+
+PATCHED=0
+ALREADY=0
+
+patch_file() {
+  F="$1"
+  [ -n "$F" ] && [ -f "$F" ] || return 0
+  if grep -q 'new URL(origin)\.hostname === hostUrl\.hostname' "$F"; then
+    ALREADY=$((ALREADY + 1))
+    echo "ORIGIN_PORT_ALREADY: $F"
+    return 0
+  fi
+  if grep -q 'new URL(origin)\.host === hostUrl\.host' "$F"; then
+    sed -i 's|new URL(origin)\.host === hostUrl\.host|new URL(origin).hostname === hostUrl.hostname|' "$F"
+    if grep -q 'new URL(origin)\.hostname === hostUrl\.hostname' "$F"; then
+      PATCHED=$((PATCHED + 1))
+      echo "ORIGIN_PORT_PATCHED: $F"
+    else
+      echo "ORIGIN_PORT_PATCH_FAILED: $F"
+    fi
+  else
+    # 找不到原字符串：可能是 LAN 补丁已把 isTrustedApiRequest 改为 return true，
+    # 或 dsh 新版本已修复/改写法。不算失败。
+    echo "ORIGIN_PORT_SKIP: $F"
+  fi
+}
+
+# ===== 1) 快速路径：RC6 npm 全局安装（扁平/嵌套两种布局都覆盖） + 源码树 =====
+for F in \
+  $(find /usr/local/lib/node_modules -path '*/@deepseek-ai/dsh-client-connection/lib/index.js' 2>/dev/null | head -5) \
+  /root/deepseek-harness/packages/client/connection/lib/index.js; do
+  patch_file "$F"
+done
+
+# ===== 2) 全量兜底：dsh 版本/路径变化时仍能命中 =====
+FALLBACK=$(grep -rl 'new URL(origin)\.host === hostUrl\.host' \
+  /usr/local/lib/node_modules/@deepseek-ai /root/deepseek-harness/packages \
+  --include='*.js' 2>/dev/null | head -20)
+for F in $FALLBACK; do
+  patch_file "$F"
+done
+
+if [ "$PATCHED" -gt 0 ]; then
+  echo "ORIGIN_PORT_OK:${PATCHED}"
+  exit 0
+fi
+if [ "$ALREADY" -gt 0 ]; then
+  echo "ORIGIN_PORT_ALREADY"
+  exit 0
+fi
+echo "ORIGIN_PORT_DONE"
+exit 0

--- a/app/src/main/assets/webui-polyfill.sh
+++ b/app/src/main/assets/webui-polyfill.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# WebUI 老浏览器兼容补丁：AbortSignal.any / AbortSignal.timeout（Chrome 118+ / Safari 17.4+ 才有）
-# 在浏览器端 bundle 头部注入 polyfill（幂等：已注入则跳过）
+# WebUI 老浏览器兼容补丁：AbortSignal.any / AbortSignal.timeout（Chrome 116+ / Safari 17.4+ 才有）
+# 在浏览器端 bundle 头部注入 polyfill（幂等：已注入则跳过）。
+# 老版本 Android System WebView 没有这两个 API，dsh 前端在选择工作区等
+# 带取消的 remote 调用上会抛 "AbortSignal.any is not a function"。
 POLY=$(cat <<'PLY'
 if (typeof AbortSignal !== 'undefined' && !AbortSignal.any) {
   AbortSignal.any = function (signals) {
@@ -25,15 +27,34 @@ if (typeof AbortSignal !== 'undefined' && !AbortSignal.timeout) {
 PLY
 )
 
+inject() {
+  F="$1"
+  [ -n "$F" ] && [ -f "$F" ] || return 0
+  if grep -q 'AbortSignal.any = function' "$F"; then
+    echo "跳过（已注入）: $F"
+    return 0
+  fi
+  { echo "$POLY"; cat "$F"; } > "$F.new" && mv "$F.new" "$F"
+  echo "已注入 polyfill: $F"
+}
+
+# ===== 1) 快速路径（最常见部署形态直接命中，O(1)） =====
 for F in \
   $(find /usr/local/lib/node_modules -path '*/@deepseek-ai/dsh-client-connection/lib/client.js' 2>/dev/null | head -1) \
   $(find /usr/local/lib/node_modules -path '*/@deepseek-ai/dsh-api-gateway/lib/client.js' 2>/dev/null | head -1) \
   /root/deepseek-harness/packages/client/connection/lib/client.js \
   /root/deepseek-harness/packages/api/gateway/lib/client.js; do
-  if [ -f "$F" ] && ! grep -q 'AbortSignal.any = function' "$F"; then
-    { echo "$POLY"; cat "$F"; } > "$F.new" && mv "$F.new" "$F"
-    echo "已注入 polyfill: $F"
-  else
-    echo "跳过（已注入或不存在）: $F"
-  fi
+  inject "$F"
 done
+
+# ===== 2) 全量兜底（dsh 版本/路径变化时仍能命中） =====
+# 快速路径未命中或未覆盖时，扫描所有 @deepseek-ai 编译产物与源码树里
+# 实际调用 AbortSignal.any/timeout 的 JS 文件，逐个幂等注入。
+FALLBACK=$(grep -rlE 'AbortSignal\.(any|timeout)' \
+  /usr/local/lib/node_modules/@deepseek-ai /root/deepseek-harness/packages \
+  --include='*.js' 2>/dev/null | head -40)
+for F in $FALLBACK; do
+  inject "$F"
+done
+
+echo "POLYFILL_DONE"

--- a/app/src/main/java/com/deepseekharness/app/HarnessController.java
+++ b/app/src/main/java/com/deepseekharness/app/HarnessController.java
@@ -729,6 +729,23 @@ public class HarnessController {
         }
     }
 
+    /** 确保外部浏览器 /api 403 修复已应用（Chrome 150+ Origin 省略端口，幂等）。
+     *  dsh-client-connection 的 isTrustedApiRequest 用 new URL(origin).host === hostUrl.host
+     *  比较 Origin 与 Host；Chrome 150+ 对 loopback 同源请求发送的 Origin 省略端口，
+     *  导致 127.0.0.1:3080 页面所有 /api 请求被 403 拒绝，表现为外部浏览器无法连接网络。
+     *  修复为只比较 hostname；失败不阻塞启动。 */
+    private void ensureWebUiOriginPatch() {
+        try {
+            String script = readAsset("webui-origin-port-patch.sh");
+            if (script == null || script.isEmpty()) return;
+            java.io.File f = new java.io.File(proot.getRootfsDir(), "root/dsha-origin-port-patch.sh");
+            f.getParentFile().mkdirs();
+            java.nio.file.Files.write(f.toPath(), script.getBytes(StandardCharsets.UTF_8));
+            proot.execAndRead("bash /root/dsha-origin-port-patch.sh; rm -f /root/dsha-origin-port-patch.sh");
+        } catch (Throwable ignored) {
+        }
+    }
+
     public void maybePrewarmWeb() {
         try {
             ensureWebUiDegrade(); // 每次启动前置自愈（幂等秒回，防插件失败卡启动）
@@ -990,6 +1007,10 @@ public class HarnessController {
             ensureWebUiPolyfill(); // WebView 老版本 AbortSignal.any/timeout polyfill（幂等）
         } catch (Throwable ignored) {
         }
+        try {
+            ensureWebUiOriginPatch(); // 外部浏览器 /api 403 修复（Chrome 150+ Origin 省略端口）
+        } catch (Throwable ignored) {
+        }
         // ===== 原生内置移动端 UI 适配（免第三方插件） =====
         // 把 dsh-client-ui-mobile-adapt 的 client 产物直接注入 web-app 前端，
         // 手机端单栏/抽屉/汉堡/全屏设置开箱即用。幂等，失败不阻塞安装。
@@ -1215,6 +1236,10 @@ public class HarnessController {
         // 立即打老 WebView 兼容补丁：单独重装⑤（dsh 更新）时不会走⑥，这里保证 RC6 路径也生效
         try {
             ensureWebUiPolyfill();
+        } catch (Throwable ignored) {
+        }
+        try {
+            ensureWebUiOriginPatch();
         } catch (Throwable ignored) {
         }
         setProgress("RC 安装完成", 100);
@@ -1589,6 +1614,11 @@ public class HarnessController {
         // 启动前自愈：老 WebView 兼容补丁（AbortSignal.any/timeout polyfill，幂等）
         try {
             ensureWebUiPolyfill();
+        } catch (Throwable ignored) {
+        }
+        // 启动前自愈：外部浏览器 /api 403 修复（Chrome 150+ Origin 省略端口，幂等）
+        try {
+            ensureWebUiOriginPatch();
         } catch (Throwable ignored) {
         }
         // 启动前自愈：内置插件（mobile-adapt/device-shell-guide）注册校验，
@@ -2100,7 +2130,7 @@ public class HarnessController {
     private static final String GUARD_VERSION = "8";
     /** 步骤⑥整体版本号：内置插件/补丁/极简 preset 任一变更时 +1，
      *  启动时对比 rootfs 标记，不符则自动重跑⑥（防"改了不生效"）。 */
-    private static final String STEP6_VERSION = "2";
+    private static final String STEP6_VERSION = "3";
 
     /** 确保 rootfs 内危险命令确认包装器已部署（版本不匹配则强制重装，幂等） */
     public void ensureDangerGuard() {

--- a/app/src/main/java/com/deepseekharness/app/HarnessController.java
+++ b/app/src/main/java/com/deepseekharness/app/HarnessController.java
@@ -713,6 +713,22 @@ public class HarnessController {
         }
     }
 
+    /** 确保 WebUI 老浏览器兼容补丁已应用（AbortSignal.any/timeout polyfill，幂等）。
+     *  老版本 Android System WebView（< Chrome 116）没有 AbortSignal.any/timeout，
+     *  dsh 前端在选择工作区等带取消的 remote 调用上会抛 "AbortSignal.any is not a function"。
+     *  RC6 / 源码构建通用；失败不阻塞启动。 */
+    private void ensureWebUiPolyfill() {
+        try {
+            String script = readAsset("webui-polyfill.sh");
+            if (script == null || script.isEmpty()) return;
+            java.io.File f = new java.io.File(proot.getRootfsDir(), "root/dsha-webui-polyfill.sh");
+            f.getParentFile().mkdirs();
+            java.nio.file.Files.write(f.toPath(), script.getBytes(StandardCharsets.UTF_8));
+            proot.execAndRead("bash /root/dsha-webui-polyfill.sh; rm -f /root/dsha-webui-polyfill.sh");
+        } catch (Throwable ignored) {
+        }
+    }
+
     public void maybePrewarmWeb() {
         try {
             ensureWebUiDegrade(); // 每次启动前置自愈（幂等秒回，防插件失败卡启动）
@@ -966,10 +982,14 @@ public class HarnessController {
         ensureDangerGuard();   // PATH 包装器（rm/adb 等 15 命令）
         ensureBashGuardPatch(); // bash 工具 lib 强制加载 dsh-guard
         try {
-            proot.ensureRuntimeFiles(); // polyfill / 运行环境文件
+            proot.ensureRuntimeFiles(); // 运行环境文件
         } catch (Throwable ignored) {
         }
         ensureWatchdogFiles();  // 看门狗 + 重启命令（最新端口）
+        try {
+            ensureWebUiPolyfill(); // WebView 老版本 AbortSignal.any/timeout polyfill（幂等）
+        } catch (Throwable ignored) {
+        }
         // ===== 原生内置移动端 UI 适配（免第三方插件） =====
         // 把 dsh-client-ui-mobile-adapt 的 client 产物直接注入 web-app 前端，
         // 手机端单栏/抽屉/汉堡/全屏设置开箱即用。幂等，失败不阻塞安装。
@@ -1192,6 +1212,11 @@ public class HarnessController {
                 "(cd \"$npty_dir\" && node-gyp rebuild > /tmp/rc6-gyp.log 2>&1) || " +
                 "{ echo 'node-pty 编译失败：'; tail -10 /tmp/rc6-gyp.log 2>&1; exit 1; }; fi; " +
                 "ls \"$npty_dir/build/Release/pty.node\" >/dev/null 2>&1 && echo 'pty.node 已就绪' && command -v dsh && echo 'RC 安装完成'");
+        // 立即打老 WebView 兼容补丁：单独重装⑤（dsh 更新）时不会走⑥，这里保证 RC6 路径也生效
+        try {
+            ensureWebUiPolyfill();
+        } catch (Throwable ignored) {
+        }
         setProgress("RC 安装完成", 100);
     }
 
@@ -1561,6 +1586,11 @@ public class HarnessController {
     public String startWebCommand() {
         // 启动前自愈：确保配置修复脚本已就位（钳制超限 timeoutMs）
         ensureConfigFixAsset();
+        // 启动前自愈：老 WebView 兼容补丁（AbortSignal.any/timeout polyfill，幂等）
+        try {
+            ensureWebUiPolyfill();
+        } catch (Throwable ignored) {
+        }
         // 启动前自愈：内置插件（mobile-adapt/device-shell-guide）注册校验，
         // 被 dsh plugin reconcile 清掉/丢失时自动补回（幂等）
         try {
@@ -2070,7 +2100,7 @@ public class HarnessController {
     private static final String GUARD_VERSION = "8";
     /** 步骤⑥整体版本号：内置插件/补丁/极简 preset 任一变更时 +1，
      *  启动时对比 rootfs 标记，不符则自动重跑⑥（防"改了不生效"）。 */
-    private static final String STEP6_VERSION = "1";
+    private static final String STEP6_VERSION = "2";
 
     /** 确保 rootfs 内危险命令确认包装器已部署（版本不匹配则强制重装，幂等） */
     public void ensureDangerGuard() {

--- a/scripts/ci-make-offline-bundle.sh
+++ b/scripts/ci-make-offline-bundle.sh
@@ -111,7 +111,7 @@ fi
 
 log "[4/6] 注入预装脚本与补丁"
 sudo mkdir -p "$ROOTFS_DIR/root/patches"
-for f in webui-sidebar.patch bash-guard.patch webui-polyfill.sh rootfs-confirm-install.sh; do
+for f in webui-sidebar.patch bash-guard.patch webui-polyfill.sh webui-origin-port-patch.sh rootfs-confirm-install.sh; do
   if [ -f "$REPO_ROOT/app/src/main/assets/$f" ]; then
     sudo cp "$REPO_ROOT/app/src/main/assets/$f" "$ROOTFS_DIR/root/patches/$f"
   fi

--- a/scripts/ci/android-build.yml
+++ b/scripts/ci/android-build.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bundle/offline-rootfs.tar.gz
-          key: offline-rootfs-${{ hashFiles('scripts/offline-provision.sh', 'scripts/ci-make-offline-bundle.sh', 'app/src/main/assets/rootfs-confirm-install.sh', 'app/src/main/assets/webui-polyfill.sh', 'app/src/main/assets/*.patch') }}
+          key: offline-rootfs-${{ hashFiles('scripts/offline-provision.sh', 'scripts/ci-make-offline-bundle.sh', 'app/src/main/assets/rootfs-confirm-install.sh', 'app/src/main/assets/webui-polyfill.sh', 'app/src/main/assets/webui-origin-port-patch.sh', 'app/src/main/assets/*.patch') }}
 
       - name: Build offline rootfs bundle
         if: steps.cache.outputs.cache-hit != 'true'

--- a/scripts/make-offline-bundle.sh
+++ b/scripts/make-offline-bundle.sh
@@ -75,7 +75,7 @@ PROOT_ARGS=(
 echo "==> [5/7] 注入预装脚本与补丁"
 "${PROOT_ARGS[@]}" /usr/bin/bash -c "mkdir -p /root/patches" 2>/dev/null
 if [ -d "$REPO_ROOT/app/src/main/assets" ]; then
-  for f in webui-sidebar.patch bash-guard.patch webui-polyfill.sh rootfs-confirm-install.sh; do
+  for f in webui-sidebar.patch bash-guard.patch webui-polyfill.sh webui-origin-port-patch.sh rootfs-confirm-install.sh; do
     cp "$REPO_ROOT/app/src/main/assets/$f" "$ROOTFS_DIR/root/patches/$f" 2>/dev/null || true
   done
 fi

--- a/scripts/offline-provision.sh
+++ b/scripts/offline-provision.sh
@@ -145,6 +145,9 @@ fi
 if [ -f /root/patches/webui-polyfill.sh ]; then
   bash /root/patches/webui-polyfill.sh || true
 fi
+if [ -f /root/patches/webui-origin-port-patch.sh ]; then
+  bash /root/patches/webui-origin-port-patch.sh || true
+fi
 
 echo "==> [7/8] 安装危险命令确认包装器"
 if [ -f /root/patches/rootfs-confirm-install.sh ]; then


### PR DESCRIPTION
## 问题

### 问题 1：老 WebView 选择工作区弹 `AbortSignal.any is not a function`

老版本 Android System WebView（< Chrome 116）没有 `AbortSignal.any` / `AbortSignal.timeout`。deepseek-harness 前端在「选择工作区」等带取消的 remote 调用上会抛：

`AbortSignal.any is not a function (internal)`

### 问题 2：外部浏览器访问 127.0.0.1:3080 时 /api 全部 403，表现为无法连接网络

内置 WebView 正常，但 Chrome 150+ 外部浏览器访问 `http://127.0.0.1:3080` 时，dsh-client-connection 的 `isTrustedApiRequest` 用 `new URL(origin).host === hostUrl.host` 比较 Origin 与 Host；Chrome 150+ 对 loopback 同源请求发送的 Origin 省略端口（`http://127.0.0.1`），与 Host（`127.0.0.1:3080`）比较失败，导致所有 `/api/*` 请求被 403 拒绝。

## 根因

两个问题都源于 DSHA 已有/应有的 rootfs 补丁没有在 RC6 默认安装路径与启动前自愈路径中生效：

- `webui-polyfill.sh` 只挂在 `installHarnessFromSource()` 源码构建分支，而 `useRc6()` 恒为 `true`，默认 RC6/npm 路径永远不会执行；
- 缺少针对 Chrome 150+ Origin 端口省略问题的补丁，且 `lan-bind-patch.sh` 只在局域网模式下执行。

## 修改

- 新增 `HarnessController.ensureWebUiPolyfill()`：幂等执行 `webui-polyfill.sh`
- 新增 `HarnessController.ensureWebUiOriginPatch()`：幂等执行新增的 `webui-origin-port-patch.sh`
  - 将 `isTrustedApiRequest` 中 `new URL(origin).host === hostUrl.host` 改为 `new URL(origin).hostname === hostUrl.hostname`
  - 端口不是 CSRF / DNS-rebinding 边界，比较 hostname 不降低安全性
- 在 `installGuard()`、`startWebCommand()`、`installHarnessRc6()` 三处调用上述两个补丁：
  - 第⑥步重跑时补打
  - 每次启动 Web UI 前自愈
  - 单独重装⑤（dsh 升级）后立即补打
- `STEP6_VERSION` 1 → 3：老设备启动时自动重跑第⑥步，无需用户重装
- 强化 `webui-polyfill.sh`：保留固定快速路径，新增对 `/usr/local/lib/node_modules/@deepseek-ai` 与源码树中实际调用 `AbortSignal.any/timeout` 的 JS 文件的全量兜底扫描
- 离线包构建脚本同步携带新补丁：`offline-provision.sh` 执行新补丁，`ci-make-offline-bundle.sh` / `make-offline-bundle.sh` 注入新补丁文件，CI 缓存 key 加入新文件哈希

## 验证

- `bash -n` 通过（新增脚本及改动脚本）
- `git diff --check` 通过
- 新补丁脚本已用临时目录模拟 dsh 包结构验证 `ORIGIN_PORT_PATCHED` 生效
- 本地缺少 Android SDK/离线 rootfs，未做 APK 级构建验证；建议在旧 WebView 真机与 Chrome 150+ 外部浏览器场景分别验证