### PR TITLE
fix: 修复 3090 确认桥安全漏洞——确认机制完全失效

### DIFF
--- a/app/src/main/assets/adb-shell.py
+++ b/app/src/main/assets/adb-shell.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# DSHA_ADB_SCRIPT_VERSION=4
+# DSHA_ADB_SCRIPT_VERSION=5
+# 注意：上面这行只是给人看的，Java 侧不读它。真正决定脚本是否重注入到 rootfs 的
+# 是 AdbBridge.SCRIPT_VERSION（比对 /root/.dsh/script-version）——改本文件必须同时 bump 它。
 """
 DSHA 设备 shell 工具（ADB 无线通道，免 Shizuku）。
 用法：
@@ -8,14 +10,97 @@ DSHA 设备 shell 工具（ADB 无线通道，免 Shizuku）。
   /root/dsh-bin/adb-shell "命令"     # 包装命令（PATH 内）
 连接端口优先级：--port > /root/.dsh/adbkeys/connect_port > 5555
 输出：stdout + "\n[EXIT=n]"（与 3090 桥保持一致的格式）
+
+安全：非只读命令先走 App 的 3090 确认桥，拿到 {"result":"YES"} 才执行；
+桥不可达 / 用户拒绝 / 任何异常都拒绝执行（fail-closed）。
+DSH_INTERNAL=1 时跳过确认，供 App 自己的内部调用使用。
+注意这一层是防呆而非安全边界——容器内是 root，能改本脚本、也能直接调
+adb_shell_wifi 库。真正的强制点在 App 侧的 3090 桥。
 """
 import sys
 import os
+import re
 import time
 
 KEYDIR = '/root/.dsh/adbkeys'
 KEY = KEYDIR + '/adbkey'
 KEYPUB = KEY + '.pub'
+TOKEN_FILE = '/root/.dsh/.bridge_token'
+# 桥可能只监听 IPv6 回环（Android 上 localhost 解析优先 ::1），两个都试
+BRIDGE_BASES = ('http://127.0.0.1:3090', 'http://[::1]:3090')
+
+# 只读命令白名单：用白名单而非黑名单——黑名单挡不住 base64/eval 之类的编码绕过
+READONLY_PREFIXES = (
+    'id', 'whoami', 'getprop', 'dumpsys', 'logcat', 'ps', 'ls', 'cat', 'df',
+    'uptime', 'date', 'pwd', 'stat', 'wc', 'head', 'tail', 'grep',
+    'settings get', 'pm list', 'wm size', 'wm density', 'service list',
+    'cmd package list', 'am stack list', 'getevent -l',
+)
+# 含重定向 / 管道 / 命令替换 / 串联的一律视为写操作（cat 能读、cat > 就能写）
+_SHELL_META = re.compile(r'[>;|&`]|\$\(')
+
+
+def is_readonly(cmd):
+    """命令是否属于纯只读查询（免确认）。判不准就返回 False，宁可多问一次。"""
+    if _SHELL_META.search(cmd):
+        return False
+    head = cmd.strip().lower()
+    return any(head == p or head.startswith(p + ' ') for p in READONLY_PREFIXES)
+
+
+def request_confirm(cmd):
+    """向 App 3090 桥请求用户确认。只有明确收到 YES 才返回 True。
+
+    返回 (allowed, reason)：reason 用于把「用户拒绝」和「桥不可达」区分开，
+    否则用户只看到一句 USER_REJECTED，根本没法排查。
+    """
+    import json
+    from urllib.parse import quote
+    from urllib.request import urlopen
+
+    try:
+        with open(TOKEN_FILE) as f:
+            token = f.read().strip()
+    except Exception:
+        return False, '读不到 %s（App 未生成鉴权令牌）' % TOKEN_FILE
+    if not token:
+        return False, '%s 为空（App 未生成鉴权令牌）' % TOKEN_FILE
+
+    last = '3090 确认桥不可达（127.0.0.1 与 [::1] 都连不上）'
+    for base in BRIDGE_BASES:
+        url = '%s/confirm?cmd=%s&token=%s' % (base, quote(cmd), quote(token))
+        try:
+            # 超时要大于 App 侧 60s 确认超时，否则这边先断、用户点了也白点
+            with urlopen(url, timeout=70) as r:
+                data = json.loads(r.read().decode('utf-8', 'replace'))
+        except Exception as e:
+            last = '请求 %s 失败：%s' % (base, e)
+            continue
+        res = data.get('result')
+        if res == 'YES':
+            return True, ''
+        if res == 'NO':
+            return False, '用户点了拒绝'
+        return False, '桥返回 %r（确认未通过）' % (res,)
+    return False, last
+
+
+def confirm_or_exit(cmd):
+    """执行前的确认关卡。不通过就直接退出（fail-closed）。"""
+    if os.environ.get('DSH_INTERNAL') == '1':
+        return  # App 内部调用（pm grant / 看门狗探活）
+    if is_readonly(cmd):
+        return
+    allowed, reason = request_confirm(cmd)
+    if allowed:
+        return
+    print('USER_REJECTED: 未获授权，命令未执行')
+    print('  命令：%s' % cmd)
+    print('  原因：%s' % reason)
+    if '不可达' in reason or '失败' in reason or '读不到' in reason or '为空' in reason:
+        print('  处理：在 App「配置」页开启 ADB 开关，让确认桥运行后重试')
+    print('[EXIT=1]')
+    sys.exit(1)
 
 
 def main():
@@ -61,6 +146,10 @@ def main():
         print('请重开 App 配置页的 ADB 开关，或重跑安装步骤⑥（会自动安装依赖）')
         print('[EXIT=1]')
         sys.exit(1)
+
+    # 安全关卡：非只读命令必须先拿到用户确认（--su 提权一律走确认）。
+    # 放在密钥/依赖检查之后：环境本来就没就绪时不该先打扰用户点确认。
+    confirm_or_exit(cmd)
 
     try:
         signer = PythonRSASigner(open(KEYPUB, 'rb').read().strip(), open(KEY, 'rb').read())

--- a/app/src/main/assets/rootfs-confirm-install.sh
+++ b/app/src/main/assets/rootfs-confirm-install.sh
@@ -7,20 +7,41 @@ mkdir -p "$DSH_BIN"
 
 cat > /root/dsh-confirm.sh <<'EOF'
 #!/bin/bash
+# DSHA 危险命令确认（走 App 3090 桥）。退出码：0=用户允许，1=拒绝/不可达
 CMD="$*"
-RES=$(curl -s -m 65 -G "http://127.0.0.1:3090/confirm" --data-urlencode "cmd=$CMD" 2>/dev/null)
-if [ $? -eq 0 ] && [ -n "$RES" ]; then
-  echo "$RES" | grep -q YES && exit 0 || exit 1
+# 桥要求 token 鉴权：不带的话一律 [UNAUTHORIZED]，所有守卫命令都会被拒
+TOKEN=$(cat /root/.dsh/.bridge_token 2>/dev/null)
+if [ -n "$TOKEN" ]; then
+  # 双地址：App 桥可能只监听 IPv6 回环（Android 上 localhost 解析优先 ::1）
+  for BASE in "http://127.0.0.1:3090" "http://[::1]:3090"; do
+    # -m 70 必须大于 App 侧 60s 确认超时，否则客户端先断、用户点了也白点
+    RES=$(curl -s -m 70 -G "$BASE/confirm" \
+            --data-urlencode "cmd=$CMD" --data-urlencode "token=$TOKEN" 2>/dev/null)
+    # 严格匹配 {"result":"YES"}：宽松的 grep YES 会被命令内容或其它字段带偏
+    case "$RES" in
+      *'"result":"YES"'*) exit 0 ;;
+      *'"result":"NO"'*)  echo "已拒绝: $CMD（用户点了拒绝）" >&2; exit 1 ;;
+    esac
+  done
 fi
-# 3090 不可达（终端场景未启动服务）：终端内交互确认，10 秒超时默认拒绝
+# 桥不可达或没有 token：终端场景交互确认，10 秒超时默认拒绝
 if [ -n "$DSH_INTERACTIVE" ]; then
   echo -n "确认执行 [$CMD] ? [y/N] " >&2
   read -t 10 ans
   case "$ans" in
     y|Y) exit 0 ;;
   esac
+  echo "已拒绝: $CMD" >&2
+  exit 1
 fi
+# 静默拒绝最难排查——把原因写清楚（用户报的 USER_REJECTED 就是卡在这里）
 echo "已拒绝: $CMD" >&2
+if [ -z "$TOKEN" ]; then
+  echo "  原因：读不到 /root/.dsh/.bridge_token（App 未生成鉴权令牌）" >&2
+else
+  echo "  原因：3090 确认桥不可达（127.0.0.1 与 [::1] 都连不上）" >&2
+fi
+echo "  处理：在 App「配置」页开启 ADB 开关，确认桥运行后重试" >&2
 exit 1
 EOF
 chmod +x /root/dsh-confirm.sh
@@ -113,4 +134,6 @@ chmod +x "$DSH_BIN/$C"
 done
 
 echo "OK dsh-bin: $(ls "$DSH_BIN" | tr '\n' ' ')"
-echo 9 > "$DSH_BIN/.version"
+# 版本号必须与 HarnessController.GUARD_VERSION 完全一致，否则 ensureDangerGuard()
+# 的 equals 永远为假 → 每次启动 Web / 开终端都 rm -rf 重装守卫（顺带删掉 adb-shell）
+echo 10 > "$DSH_BIN/.version"

--- a/app/src/main/java/com/deepseekharness/app/AdbBridge.java
+++ b/app/src/main/java/com/deepseekharness/app/AdbBridge.java
@@ -22,14 +22,17 @@ public final class AdbBridge {
     private AdbBridge() {
     }
 
-    /** assets 脚本是否已注入 rootfs（校验版本标记，防止旧脚本残留不更新） */
+    /** assets 脚本是否已注入 rootfs（校验版本标记，防止旧脚本残留不更新）。
+     *  用 equals 而非 contains：contains 会把 "10" 里的 "1"、"18" 里的 "8"
+     *  当成命中，版本号一进两位数就会误判为"已注入"而跳过重注入。 */
     public static boolean injected(ProotBootstrap proot) {
         String r = proot.execAndRead("test -f /root/.dsh/script-version && cat /root/.dsh/script-version || echo NO");
-        return r != null && r.trim().contains(SCRIPT_VERSION);
+        return r != null && r.trim().equals(SCRIPT_VERSION);
     }
 
-    /** 当前 assets 脚本版本：每次改脚本 +1，旧版 APK 的残留脚本会因版本不符被强制重注入 */
-    private static final String SCRIPT_VERSION = "7";
+    /** 当前 assets 脚本版本：每次改脚本 +1，旧版 APK 的残留脚本会因版本不符被强制重注入。
+     *  这是唯一生效的门——脚本头部的 # DSHA_ADB_SCRIPT_VERSION 注释 Java 侧不读。 */
+    private static final String SCRIPT_VERSION = "8";
 
     /** 幂等注入：把三个 assets 脚本 base64 写入 /root/.dsh/ 并加执行位 + 写版本标记 */
     public static String inject(Context ctx, ProotBootstrap proot) {
@@ -165,7 +168,9 @@ public final class AdbBridge {
         try {
             String pkg = "com.dsh.client";
             // 先查是否已授权，避免每次配对都重复 grant
-            String r = proot.execAndRead("python3 /root/.dsh/adb-shell.py pm grant " + pkg
+            // DSH_INTERNAL=1：跳过 adb-shell.py 的用户确认关卡（App 自己的调用，
+            // pm grant 不是只读命令，不打标会弹窗骚扰用户）
+            String r = proot.execAndRead("DSH_INTERNAL=1 python3 /root/.dsh/adb-shell.py pm grant " + pkg
                     + " android.permission.WRITE_SECURE_SETTINGS 2>&1 | head -2");
             android.util.Log.i("DSHA-ADB", "WRITE_SECURE_SETTINGS 授权结果: " + r);
         } catch (Throwable ignored) {

--- a/app/src/main/java/com/deepseekharness/app/ConfigFragment.java
+++ b/app/src/main/java/com/deepseekharness/app/ConfigFragment.java
@@ -125,7 +125,8 @@ public class ConfigFragment extends Fragment {
         new Thread(() -> {
             try {
                 // 探测 adb 是否真实可用（用 rootfs 里的 adb-shell 实际跑一下，最准）
-                String r = c.getProot().execAndRead("python3 /root/.dsh/adb-shell.py id 2>&1 | head -2");
+                // DSH_INTERNAL=1：App 自己的探活不走用户确认关卡
+                String r = c.getProot().execAndRead("DSH_INTERNAL=1 python3 /root/.dsh/adb-shell.py id 2>&1 | head -2");
                 final boolean connected = r != null && r.contains("uid=");
                 final String detail = r == null ? "" : r.replace("\n", " ").trim();
                 if (isAdded()) requireActivity().runOnUiThread(() -> {
@@ -149,6 +150,32 @@ public class ConfigFragment extends Fragment {
     public void onResume() {
         super.onResume();
         startAdbStatusPolling();
+        showGuardStatus(); // 上次启动 Web 时补丁可能已失配，切回本页就刷新
+    }
+
+    /** 危险命令守卫的完整性提示。
+     *  bash 工具补丁靠 sed 匹配 dsh 已构建代码，而 dsh 走"始终最新 RC"自动升级，
+     *  上游一改代码这层保险就静默降级——必须让用户看得见，
+     *  否则会以为确认仍是「PATH 包装器 + 函数级守卫」双保险。 */
+    private void showGuardStatus() {
+        View v = getView();
+        TextView tv = v == null ? null : v.findViewById(R.id.config_guard_status);
+        if (tv == null || c == null) return;
+        String st = c.guardPatchState();
+        if ("unknown".equals(st)) {
+            tv.setVisibility(View.GONE); // 还没启动过 Web，无从判断，不必吓人
+            return;
+        }
+        tv.setVisibility(View.VISIBLE);
+        if ("ok".equals(st)) {
+            tv.setTextColor(requireContext().getColor(R.color.ok));
+            tv.setText("● 守卫完整：PATH 包装器 + bash 工具补丁");
+        } else {
+            tv.setTextColor(requireContext().getColor(R.color.warn));
+            tv.setText("○ bash 工具补丁未生效（dsh 可能已升级改动代码）\n"
+                    + "危险命令仍会被 PATH 包装器拦截并弹确认，只是少一层兜底。\n"
+                    + "详情见容器内 /root/dsh-guard-patch.log");
+        }
     }
 
     @Override
@@ -284,6 +311,7 @@ public class ConfigFragment extends Fragment {
         confirmShellCb.setChecked(requireContext()
                 .getSharedPreferences("deepseekharness", android.content.Context.MODE_PRIVATE)
                 .getBoolean("confirm_shell", true));
+        showGuardStatus();
         checkUpdateCb.setChecked(requireContext()
                 .getSharedPreferences("deepseekharness", android.content.Context.MODE_PRIVATE)
                 .getBoolean("check_update", true));

--- a/app/src/main/java/com/deepseekharness/app/ConfirmReceiver.java
+++ b/app/src/main/java/com/deepseekharness/app/ConfirmReceiver.java
@@ -7,17 +7,22 @@ import android.content.Intent;
 /**
  * 后台安全确认通知的按钮接收器：用户点「允许/拒绝」后
  * 通知 HttpShellService 释放挂起的确认。
+ *
+ * epoch 随 Intent 传回，由 HttpShellService 校验：残留通知（锁屏、通知历史、
+ * 手表转发）上的旧按钮带的是过期 epoch，会被丢弃，不会误授权给当前请求。
  */
 public class ConfirmReceiver extends BroadcastReceiver {
 
     public static final String ACTION_ALLOW = "com.deepseekharness.app.CONFIRM_ALLOW";
     public static final String ACTION_DENY = "com.deepseekharness.app.CONFIRM_DENY";
+    public static final String EXTRA_EPOCH = "confirm_epoch";
 
     @Override
     public void onReceive(Context context, Intent intent) {
         HttpShellService svc = HttpShellService.instance();
         if (svc != null) {
-            svc.resolveConfirm(ACTION_ALLOW.equals(intent.getAction()));
+            svc.resolveConfirm(ACTION_ALLOW.equals(intent.getAction()),
+                    intent.getLongExtra(EXTRA_EPOCH, -1L));
         }
     }
 }

--- a/app/src/main/java/com/deepseekharness/app/DeviceBridgeService.java
+++ b/app/src/main/java/com/deepseekharness/app/DeviceBridgeService.java
@@ -206,11 +206,22 @@ public class DeviceBridgeService extends Service {
             public void run() {
                 if (!running || !isAdbEnabled(DeviceBridgeService.this)) return;
                 new Thread(() -> {
+                    // 3090 桥自愈：HarnessService 也会 new 一个 HttpShellService，
+                    // 谁抢到端口谁持有；它在停止 Web 时把桥关掉后，ADB 开关还开着，
+                    // agent 的确认请求就会全部 fail-closed 被拒。这里补起来。
+                    // 放在工作线程：start() 里要读写 rootfs 的 token 文件。
+                    try {
+                        if (HttpShellService.instance() == null) {
+                            new HttpShellService(DeviceBridgeService.this).start();
+                        }
+                    } catch (Throwable ignored) {
+                    }
                     try {
                         HarnessController c = HarnessController.get(DeviceBridgeService.this);
                         if (c == null || !c.getProot().isInstalled()) return;
-                        // 1. 探测当前连接是否可用
-                        String r = c.getProot().execAndRead("python3 /root/.dsh/adb-shell.py id 2>&1 | head -3");
+                        // 1. 探测当前连接是否可用（DSH_INTERNAL=1 跳过确认关卡：
+                        //    App 自己的探活不该弹窗问用户）
+                        String r = c.getProot().execAndRead("DSH_INTERNAL=1 python3 /root/.dsh/adb-shell.py id 2>&1 | head -3");
                         if (r != null && r.contains("uid=")) return; // 连接正常
                         // 库缺失（setup 未完成）→ 触发 setup 自愈（注入脚本+装依赖+装包装命令）
                         if (r != null && r.contains("DEPS_MISSING")) {
@@ -222,7 +233,7 @@ public class DeviceBridgeService extends Service {
                         if (connPort > 0) {
                             saveConnectPort(connPort);
                             // 3. 用新端口再测一次
-                            String r2 = c.getProot().execAndRead("python3 /root/.dsh/adb-shell.py --port " + connPort + " id 2>&1 | head -3");
+                            String r2 = c.getProot().execAndRead("DSH_INTERNAL=1 python3 /root/.dsh/adb-shell.py --port " + connPort + " id 2>&1 | head -3");
                             if (r2 != null && r2.contains("uid=")) {
                                 android.util.Log.i("DSHA-ADB", "看门狗：已自动重连端口 " + connPort);
                                 return;
@@ -259,7 +270,7 @@ public class DeviceBridgeService extends Service {
                             int p2 = discoverConnPortSync();
                             if (p2 > 0) {
                                 saveConnectPort(p2);
-                                c.getProot().execAndRead("python3 /root/.dsh/adb-shell.py --port " + p2 + " id 2>&1 | head -1");
+                                c.getProot().execAndRead("DSH_INTERNAL=1 python3 /root/.dsh/adb-shell.py --port " + p2 + " id 2>&1 | head -1");
                             }
                             return;
                         }

--- a/app/src/main/java/com/deepseekharness/app/HarnessController.java
+++ b/app/src/main/java/com/deepseekharness/app/HarnessController.java
@@ -597,7 +597,7 @@ public class HarnessController {
                     "order: 3\n").getBytes(StandardCharsets.UTF_8));
             String guide = "你正运行在用户 Android 手机的容器里，可以直接干预这台实体手机：\n"
                     + "- 主通道（ADB 无线，已配对）：/root/dsh-bin/adb-shell \"命令\"（shell级）；--su 提权（需root）：/root/dsh-bin/adb-shell --su \"命令\"；若不存在则用 python3 /root/.dsh/adb-shell.py \"命令\"\n"
-                    + "- 备选通道（Shizuku 桥，可能未就绪）：curl -s \"http://127.0.0.1:3090/exec?cmd=...\"\n"
+                    + "- 备选通道（Shizuku 桥，可能未就绪）：curl -s \"http://127.0.0.1:3090/exec?cmd=...&token=$(cat /root/.dsh/.bridge_token)\"（漏 token 会返回 UNAUTHORIZED）\n"
                     + "- ⚠️ 不要用 /root/dsh-bin/adb 或裸 adb 命令——那是守卫包装脚本，会失败\n"
                     + "- 常用操作：查设备信息 getprop；查前台 dumpsys window | grep mCurrentFocus；启动应用 am start -n 包名/Activity；抓日志 dumpsys/logcat；读写 /sdcard\n"
                     + "- 权限边界：shell 级（非 root），需提权操作会失败，如实告知即可\n"
@@ -674,7 +674,7 @@ public class HarnessController {
                             + "      description: |+\n"
                             + "        Run commands in a bash shell\n"
                             + "        * 设备操作：/root/dsh-bin/adb-shell \"命令\"（唯一可用通道，uid=2000，已配对）\n"
-                            + "        * 不要用裸 adb（守卫脚本，会失败）；Shizuku 桥备用 curl 127.0.0.1:3090/exec\n"
+                            + "        * 不要用裸 adb（守卫脚本，会失败）；Shizuku 桥备用 curl -s \"http://127.0.0.1:3090/exec?cmd=...&token=$(cat /root/.dsh/.bridge_token)\"\n"
                             + "        * 与用户交流请用中文回复\n";
                     hpText += patchBlock;
                     java.nio.file.Files.write(hp.toPath(), hpText.getBytes(StandardCharsets.UTF_8));
@@ -2127,7 +2127,10 @@ public class HarnessController {
     }
 
     // ================= 启动 / 停止 =================
-    private static final String GUARD_VERSION = "8";
+    /** 危险命令守卫版本：必须与 rootfs-confirm-install.sh 尾行 `echo N` 完全一致。
+     *  曾经这里是 8、脚本写 9，equals 永远为假 → 每次 startWeb/开终端都
+     *  rm -rf /root/dsh-bin 全量重装（顺带删掉 adb-shell 包装）。改一处必须改两处。 */
+    private static final String GUARD_VERSION = "10";
     /** 步骤⑥整体版本号：内置插件/补丁/极简 preset 任一变更时 +1，
      *  启动时对比 rootfs 标记，不符则自动重跑⑥（防"改了不生效"）。 */
     private static final String STEP6_VERSION = "3";
@@ -2153,21 +2156,69 @@ public class HarnessController {
         }
     }
 
-    /** 给已构建的 bash 工具 lib 直接打补丁（强制每次执行前加载守卫，不依赖重新 build）
-     *  失败时写 /root/dsh-guard-patch.log（不影响启动，日志可查） */
+    /** bash 守卫补丁状态的 prefs 键：ok / no_lib / patch_failed / unknown */
+    private static final String KEY_GUARD_PATCH = "guard_patch_state";
+
+    /** bash 守卫补丁状态（供配置页展示）。"ok" 表示补丁在位；其余表示这层保险已降级——
+     *  PATH 包装器（/root/dsh-bin）仍在拦截、3090 确认弹窗照常，只是少一层兜底。 */
+    public String guardPatchState() {
+        return prefs.getString(KEY_GUARD_PATCH, "unknown");
+    }
+
+    /** 给已构建的 bash 工具 lib 直接打补丁（强制每次执行前加载守卫，不依赖重新 build）。
+     *
+     *  这是全项目对 dsh 内部实现最脆弱的耦合：sed 匹配的是 dsh 已构建代码里的字面串
+     *  `command: request.command`，而 dsh 走"始终最新 RC"自动升级（见 installDshCommand）。
+     *  上游一改这行代码补丁就静默失配，所以结果必须记进 prefs 让配置页可见，
+     *  不能像以前那样只写一个用户永远看不到的日志文件。 */
     public void ensureBashGuardPatch() {
+        String state = "unknown";
         try {
             // RC6（npm 全局安装，依赖可能是嵌套或扁平布局，用 find 通配兼容两种）；
             // 源码版：packages/shell/bash-local
+            // 各分支都 echo 到 stdout（tee 同时留档），否则 Java 侧无法判断成败
             String wd = getWorkdir();
-            proot.execAndRead(
+            String out = proot.execAndRead(
                     "F=$(find /usr/local/lib/node_modules -path '*/@deepseek-ai/dsh-bash-local/lib/index.js' 2>/dev/null | head -1); " +
                     "if [ -z \"$F\" ]; then F=/root/" + wd + "/packages/shell/bash-local/lib/index.js; fi; " +
-                    "if [ ! -f \"$F\" ]; then echo \"守卫补丁: 未找到 bash 工具 lib\" > /root/dsh-guard-patch.log; " +
+                    "if [ ! -f \"$F\" ]; then echo '守卫补丁 NO_LIB: 未找到 bash 工具 lib' | tee /root/dsh-guard-patch.log; " +
                     "elif grep -q 'dsh-guard' \"$F\"; then echo LIB_ALREADY; " +
                     "else sed -i 's|command: request\\.command|command: `source /root/dsh-guard.sh 2>/dev/null; ${request.command}`|' \"$F\" " +
-                    "&& grep -q 'dsh-guard' \"$F\" && echo LIB_PATCHED || echo \"守卫补丁: patch 失败\" > /root/dsh-guard-patch.log; fi");
+                    "&& grep -q 'dsh-guard' \"$F\" && echo LIB_PATCHED || " +
+                    "echo '守卫补丁 PATCH_FAILED: sed 未匹配（dsh 可能已升级改动代码）' | tee /root/dsh-guard-patch.log; fi");
+            if (out != null) {
+                if (out.contains("LIB_ALREADY") || out.contains("LIB_PATCHED")) state = "ok";
+                else if (out.contains("NO_LIB")) state = "no_lib";
+                else if (out.contains("PATCH_FAILED")) state = "patch_failed";
+            }
         } catch (Exception ignored) {
+        }
+        reportGuardPatchState(state);
+    }
+
+    /** 记录补丁状态；只在状态发生变化时提示，避免每次启动 Web 都弹一次 */
+    private void reportGuardPatchState(String state) {
+        try {
+            if (state.equals(prefs.getString(KEY_GUARD_PATCH, ""))) return;
+            prefs.edit().putString(KEY_GUARD_PATCH, state).apply();
+            if ("ok".equals(state)) {
+                android.util.Log.i("DSHA", "bash 守卫补丁已就位");
+                return;
+            }
+            android.util.Log.w("DSHA", "bash 守卫补丁未生效(" + state
+                    + ")：PATH 包装器仍在拦截，但 bash 函数级守卫这层已降级");
+            final MainActivity act = MainActivity.current;
+            if (act == null) return; // 没有前台界面就只留日志，配置页照样能看到
+            new Handler(Looper.getMainLooper()).post(() -> {
+                try {
+                    android.widget.Toast.makeText(act,
+                            "⚠️ bash 守卫补丁未生效（dsh 可能已升级）\n"
+                                    + "危险命令仍会拦截并弹确认，只是少一层兜底。详见配置页",
+                            android.widget.Toast.LENGTH_LONG).show();
+                } catch (Throwable ignored) {
+                }
+            });
+        } catch (Throwable ignored) {
         }
     }
 
@@ -2446,8 +2497,9 @@ public class HarnessController {
                         android.util.Log.i("DSHA-ADB", "启动自愈 setup: " + setup);
                     }
                     // 4) 有密钥有依赖 → 探一次连接（失败交给看门狗周期重连）
+                    //    DSH_INTERNAL=1：App 自己的探活不走用户确认关卡
                     if (AdbBridge.keyPresent(proot) && AdbBridge.depsOk(proot)) {
-                        String r = proot.execAndRead("python3 /root/.dsh/adb-shell.py id 2>&1 | head -2");
+                        String r = proot.execAndRead("DSH_INTERNAL=1 python3 /root/.dsh/adb-shell.py id 2>&1 | head -2");
                         if (r != null && r.contains("uid=")) {
                             android.util.Log.i("DSHA-ADB", "启动体检：ADB 连接正常");
                         } else {

--- a/app/src/main/java/com/deepseekharness/app/HttpShellService.java
+++ b/app/src/main/java/com/deepseekharness/app/HttpShellService.java
@@ -7,48 +7,76 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import android.os.Handler;
-import android.os.Looper;
 
 import androidx.core.app.NotificationCompat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URLDecoder;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * 极简 HTTP 服务（host 侧，端口 3090），把 Shizuku shell 能力桥接给 rootfs 里的助手。
  * rootfs 内的 agent 可用 bash 工具执行：
- *   curl -s "http://127.0.0.1:3090/exec?cmd=<urlencoded>"
+ *   curl -s "http://127.0.0.1:3090/exec?cmd=<urlencoded>&token=$(cat /root/.dsh/.bridge_token)"
  * 返回 JSON：{"result":"...输出...[EXIT=0]"}
  *
- * 安全：命中危险命令（删除/格式化/卸载/重启等）时，若设置开启"需确认"，
- * 前台弹窗 / 后台高优先级通知（允许/拒绝按钮），60 秒超时默认拒绝。
+ * 端点：
+ *   /health  存活探测（仍需 token），返回 {"result":"OK"}
+ *   /exec    执行命令；命中危险命令且开关开启时先确认
+ *   /confirm 只问用户、不执行（rootfs 内包装器/adb-shell.py 用）
+ *
+ * 安全：需确认时前台弹窗 + 通知（允许/拒绝按钮）同时发，60 秒超时默认拒绝。
  */
 public final class HttpShellService {
 
-    public static final int PORT = 3090;
-    private static final String CONFIRM_CHANNEL = "dsh_confirm_channel";
+    public static final int PORT = Constants.SHELL_BRIDGE_PORT;
+    private static final String CONFIRM_CHANNEL = Constants.CHANNEL_SHELL_CONFIRM;
     private static final int CONFIRM_NOTIF_ID = Constants.NOTIF_SHELL_CONFIRM;
     private static final long CONFIRM_TIMEOUT_S = 60;
+    private static final String TAG = "DSHA-Bridge";
 
     private static volatile HttpShellService instance;
+    /** 全局"已有桥在监听"标志。HarnessService 与 DeviceBridgeService 各自 new 一个
+     *  实例并都调 start()，实例字段 running 挡不住跨实例的重复启动——第二个实例会
+     *  因端口占用绑定失败，进而把活着的那个从 instance 里抹掉（通知按钮全废）。 */
+    private static final AtomicBoolean STARTED = new AtomicBoolean(false);
 
     private final Context ctx;
-    private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private volatile CountDownLatch pendingLatch;
     private volatile boolean pendingAllow;
-    /** 确认进行中标志：并发确认请求直接拒绝（避免 latch 覆盖导致"点了允许却拒绝"） */
-    private volatile boolean confirmBusy = false;
+    /** 本实例是否真正持有监听：只有持有者的 stop() 才做清理，
+     *  否则第二个（没绑上端口的）实例一被销毁就会把真桥的状态清掉。 */
+    private volatile boolean owner;
+    /** 每次确认的序号：用来判定一次「允许/拒绝」点击属于哪个请求。
+     *  没有它的话，上一个请求残留的弹窗/通知按钮会把授权决定打到下一个请求上。 */
+    private final AtomicLong confirmEpoch = new AtomicLong();
+    /** 当前挂起的弹窗，确认完成后要主动 dismiss（setCancelable(false) 关不掉它） */
+    private volatile androidx.appcompat.app.AlertDialog pendingDialog;
+    /** 确认进行中标志：并发确认请求直接拒绝（避免 latch 覆盖导致"点了允许却拒绝"）。
+     *  用 AtomicBoolean 而不是 volatile boolean——"检查后置位"必须原子，否则两个
+     *  请求线程可能同时通过检查、互相覆盖 pendingLatch。 */
+    private final AtomicBoolean confirmBusy = new AtomicBoolean(false);
 
-    private ServerSocket server;
+    /** 双栈监听：Android 上 getLoopbackAddress() 可能只返回 ::1，而 rootfs 内的
+     *  客户端脚本大多写死 127.0.0.1 —— 只听一边会让确认链路整条断掉。
+     *  volatile：与 workers 一致，避免 start/stop 分处不同线程时读到 stale 值。 */
+    private volatile ServerSocket server4;
+    private volatile ServerSocket server6;
+    /** 每连接一个工作线程：确认请求会挂起最长 60s，串行 handle 会把整个桥堵死。
+     *  volatile：accept 线程读、调用 stop() 的线程写。 */
+    private volatile ExecutorService workers;
     private volatile boolean running;
-    /** 鉴权 token（随机生成，rootfs 内 agent 通过它访问；外部网络无法到达 127.0.0.1） */
+    /** 鉴权 token（随机生成，rootfs 内 agent 通过它访问；外部网络无法到达回环） */
     private static volatile String authToken = "";
     /** token 持久化位置（rootfs 内 agent 可读） */
     private static final String TOKEN_FILE = "/root/.dsh/.bridge_token";
@@ -61,71 +89,177 @@ public final class HttpShellService {
         return instance;
     }
 
-    /** 生成/读取鉴权 token，并写入 rootfs（agent 读取用）。
+    /** 生成 token 并确保 rootfs 内的 token 文件与内存一致。
+     *  每次 start() 都校验文件：rootfs 被重建 / 恢复备份后文件会丢，
+     *  若只在首次生成时写，客户端就永久拿不到 token（一律 UNAUTHORIZED）。 */
+    private static String ensureToken() {
+        if (authToken.isEmpty()) {
+            try {
+                authToken = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 32);
+            } catch (Throwable ignored) {
+            }
+        }
+        writeTokenToRootfs(authToken);
+        return authToken;
+    }
+
+    /** 写 token 到 rootfs（agent 读取用），内容已一致则跳过。
      *  注意：路径是 rootfs 内的 /root/.dsh/.bridge_token，App 写的是
      *  rootfs 实际目录（files/linux/ubuntu/root/.dsh/）。 */
-    private static String ensureToken() {
-        if (!authToken.isEmpty()) return authToken;
+    private static void writeTokenToRootfs(String token) {
+        if (token == null || token.isEmpty()) return;
         try {
-            String t = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 32);
-            authToken = t;
-            // 写入 rootfs（通过 HarnessController 拿 rootfs 路径；失败不影响运行）
-            try {
-                HarnessController hc = HarnessController.get(instance().ctx);
-                if (hc != null && hc.getProot() != null) {
-                    java.io.File tf = new java.io.File(hc.getProot().getRootfsDir(),
-                            "root/.dsh/.bridge_token");
-                    if (tf.getParentFile() != null) tf.getParentFile().mkdirs();
-                    try (java.io.FileOutputStream fo = new java.io.FileOutputStream(tf)) {
-                        fo.write(t.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-                    }
+            HttpShellService self = instance;
+            if (self == null) return;
+            HarnessController hc = HarnessController.get(self.ctx);
+            if (hc == null || hc.getProot() == null) return;
+            java.io.File tf = new java.io.File(hc.getProot().getRootfsDir(),
+                    TOKEN_FILE.substring(1));
+            if (tf.isFile()) {
+                try {
+                    String cur = new String(java.nio.file.Files.readAllBytes(tf.toPath()),
+                            java.nio.charset.StandardCharsets.UTF_8).trim();
+                    if (token.equals(cur)) return; // 已一致，不必重写
+                } catch (Throwable ignored) {
                 }
-            } catch (Throwable ignored) {
+            }
+            if (tf.getParentFile() != null) tf.getParentFile().mkdirs();
+            try (java.io.FileOutputStream fo = new java.io.FileOutputStream(tf)) {
+                fo.write(token.getBytes(java.nio.charset.StandardCharsets.UTF_8));
             }
         } catch (Throwable ignored) {
         }
-        return authToken;
     }
 
     public void start() {
         if (running) return;
+        // 跨实例守卫：已有桥在监听就直接放弃，不去抢端口、更不碰 instance。
+        // （两个 Service 各 new 一个实例，谁先起谁持有）
+        if (!STARTED.compareAndSet(false, true)) {
+            android.util.Log.i(TAG, "3090 桥已由另一个实例持有，本次 start 跳过");
+            return;
+        }
         running = true;
+        owner = true;
         instance = this;
         ensureToken();
+        workers = Executors.newCachedThreadPool(r -> {
+            Thread w = new Thread(r, "http-shell-work");
+            w.setDaemon(true);
+            return w;
+        });
+        // 安全：仅绑定回环地址，外部网络无法访问！
+        // （原来 new ServerSocket(PORT) 默认绑 0.0.0.0 = 局域网可访问 → 严重漏洞）
+        // 双栈：IPv4 127.0.0.1 与 IPv6 ::1 都听，客户端写哪个地址都连得上。
+        server4 = bindLoopback(loopback4(), "IPv4 127.0.0.1");
+        server6 = bindLoopback(loopback6(), "IPv6 [::1]");
+        if (server4 == null && server6 == null) {
+            running = false;
+            owner = false;
+            if (instance == this) instance = null; // 只清自己，别抹掉别人的活实例
+            ExecutorService pool = workers;
+            workers = null;
+            if (pool != null) pool.shutdownNow();
+            STARTED.set(false);
+            android.util.Log.e(TAG, "3090 桥启动失败：IPv4/IPv6 回环都绑不上");
+            return;
+        }
+        if (server4 != null) startAcceptLoop(server4, "http-shell");
+        if (server6 != null) startAcceptLoop(server6, "http-shell6");
+    }
+
+    /** 127.0.0.1（显式字节，不经名字解析——localhost 在 Android 上会解析到 ::1） */
+    private static InetAddress loopback4() {
+        try {
+            return InetAddress.getByAddress(new byte[]{127, 0, 0, 1});
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    /** ::1（16 字节，末位 1） */
+    private static InetAddress loopback6() {
+        try {
+            return InetAddress.getByAddress(
+                    new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    /** 绑一个回环地址。失败只记日志返回 null（部分设备没有 IPv6 栈），
+     *  是否致命由调用方判断（两个都绑不上才算启动失败）。
+     *  catch Throwable：受限环境下 bind 可能抛 SecurityException，
+     *  而 HarnessService.onCreate 那侧没有 try/catch 兜底，逃出去就崩服务。 */
+    private ServerSocket bindLoopback(InetAddress addr, String label) {
+        if (addr == null) return null;
+        ServerSocket s = null;
+        try {
+            s = new ServerSocket();
+            s.setReuseAddress(true);
+            s.bind(new java.net.InetSocketAddress(addr, PORT));
+            android.util.Log.i(TAG, "3090 桥已监听 " + label);
+            return s;
+        } catch (Throwable e) {
+            closeQuietly(s); // 别泄漏半开的 fd
+            android.util.Log.w(TAG, "3090 绑定失败(" + label + ")：" + e);
+            return null;
+        }
+    }
+
+    private void startAcceptLoop(final ServerSocket s, String threadName) {
         Thread t = new Thread(() -> {
-            try {
-                // 安全：仅绑定 127.0.0.1（loopback），外部网络无法访问！
-                // （原来 new ServerSocket(PORT) 默认绑 0.0.0.0 = 局域网可访问 → 严重漏洞）
-                server = new ServerSocket();
-                server.setReuseAddress(true);
-                server.bind(new java.net.InetSocketAddress(
-                        java.net.InetAddress.getLoopbackAddress(), PORT));
-                while (running) {
-                    try {
-                        Socket client = server.accept();
-                        handle(client);
-                    } catch (IOException e) {
-                        if (!running) break;
+            while (running) {
+                try {
+                    final Socket client = s.accept();
+                    // 交给线程池：确认请求最长挂起 60s，不能占住 accept 循环
+                    ExecutorService w = workers;
+                    if (w == null) {
+                        closeQuietly(client);
+                        break;
                     }
+                    try {
+                        w.execute(() -> handle(client));
+                    } catch (Throwable rejected) {
+                        closeQuietly(client);
+                    }
+                } catch (IOException e) {
+                    if (!running) break;
                 }
-            } catch (IOException ignored) {
             }
-        }, "http-shell");
+        }, threadName);
         t.setDaemon(true);
         t.start();
     }
 
     public void stop() {
+        // 非持有者（start 时被跨实例守卫挡掉的那个）什么都不该动：
+        // 否则 HarnessService.onDestroy 会把 DeviceBridgeService 那个活桥的状态清掉。
+        if (!owner) return;
+        owner = false;
         running = false;
-        instance = null;
-        try {
-            if (server != null) server.close();
-        } catch (IOException ignored) {
-        }
+        if (instance == this) instance = null;
+        closeQuietly(server4);
+        closeQuietly(server6);
+        server4 = null;
+        server6 = null;
+        ExecutorService pool = workers;
+        workers = null;
+        if (pool != null) pool.shutdownNow();
         // 释放挂起的确认（默认拒绝）
+        pendingAllow = false;
         CountDownLatch l = pendingLatch;
         if (l != null) l.countDown();
+        dismissConfirmDialog();
         cancelConfirmNotification();
+        STARTED.set(false);
+    }
+
+    private static void closeQuietly(java.io.Closeable c) {
+        try {
+            if (c != null) c.close();
+        } catch (IOException ignored) {
+        }
     }
 
     private void handle(Socket client) {
@@ -135,55 +269,55 @@ public final class HttpShellService {
             if (line == null) return;
             String[] parts = line.split(" ");
             String path = parts.length > 1 ? parts[1] : "/";
-            String cmd = "";
-            if (path.startsWith("/exec") || path.startsWith("/confirm")) {
-                int q = path.indexOf("cmd=");
-                if (q >= 0) {
-                    cmd = URLDecoder.decode(path.substring(q + 4), "UTF-8");
-                }
-            }
+
             // 鉴权：token 必须匹配（通过 ?token= 或 X-Token header）
-            boolean authed = false;
-            String t = "";
-            int tq = path.indexOf("token=");
-            if (tq >= 0) {
-                t = path.substring(tq + 6);
-                int amp = t.indexOf('&');
-                if (amp >= 0) t = t.substring(0, amp);
-                try { t = URLDecoder.decode(t, "UTF-8"); } catch (Exception ignored) { }
-            }
-            String token = authToken.isEmpty() ? ensureToken() : authToken;
-            if (!t.isEmpty() && token.equals(t)) authed = true;
+            String token = authToken;
+            if (token.isEmpty()) token = ensureToken();
+            String t = queryParam(path, "token");
+            boolean authed = !t.isEmpty() && token.equals(t);
             if (!authed) {
                 // 也支持 header 传 token（agent 引导用 curl -H）
                 try {
                     String hdr;
                     while ((hdr = reader.readLine()) != null && !hdr.isEmpty()) {
                         if (hdr.toLowerCase().startsWith("x-token:")) {
-                            String hv = hdr.substring(8).trim();
-                            if (token.equals(hv)) authed = true;
+                            if (token.equals(hdr.substring(8).trim())) authed = true;
                             break;
                         }
                     }
                 } catch (Throwable ignored) {
                 }
             }
+
+            // cmd 必须按 & 切分取：原来 indexOf("cmd=") 直接取到串尾，会把后面的
+            // &token=xxx 一起当成命令（弹窗里泄露 token，/exec 还会把它当后台任务执行）
+            String cmd = "";
+            if (path.startsWith("/exec") || path.startsWith("/confirm")) {
+                cmd = queryParam(path, "cmd");
+            }
+
             String result;
             if (!authed) {
                 result = "[UNAUTHORIZED]";
+            } else if (path.startsWith("/health")) {
+                result = "OK";
             } else if (cmd.isEmpty()) {
                 result = "[NO_CMD]";
             } else if (path.startsWith("/confirm")) {
-                // rootfs 内包装器请求的确认：只弹窗，不执行
-                result = (confirmEnabled() && DangerShellGuard.isDangerous(cmd))
-                        ? (requestUserConfirm(cmd) ? "YES" : "NO")
-                        : "YES";
+                // rootfs 内包装器请求的确认：只弹窗，不执行。
+                // 客户端主动来问 = 它已判定该命令需要授权，所以这里不再用
+                // DangerShellGuard 二次过滤——宿主名单与 rootfs 包装侧的正则是两套
+                // 规则，靠它过滤会让"客户端认为危险、App 认为不危险"的命令静默放行。
+                result = !confirmEnabled() ? "YES" : (requestUserConfirm(cmd) ? "YES" : "NO");
             } else if (DangerShellGuard.isDangerous(cmd) && confirmEnabled()) {
                 result = awaitConfirm(cmd);
             } else {
                 result = ShizukuShell.exec(cmd);
             }
-            String body = "{\"result\":" + jsonEscape(result) + "}";
+            // exec 走 AIDL 跨进程，远端可能回 null；不兜住的话 jsonQuote 抛 NPE
+            // 被下面的 catch 吞掉 → 一个字节都不回，客户端只看到"桥无响应"
+            if (result == null) result = "[NULL_RESULT]";
+            String body = "{\"result\":" + jsonQuote(result) + "}";
             byte[] bodyBytes = body.getBytes("UTF-8");
             String head = "HTTP/1.1 200 OK\r\n"
                     + "Content-Type: application/json; charset=utf-8\r\n"
@@ -197,90 +331,152 @@ public final class HttpShellService {
         }
     }
 
-    private boolean confirmEnabled() {
-        return ctx.getSharedPreferences("deepseekharness", Context.MODE_PRIVATE)
-                .getBoolean("confirm_shell", true);
+    /** 取查询参数：按 & 切分后精确匹配键名再 URL 解码；没有则返回空串。 */
+    private static String queryParam(String path, String key) {
+        if (path == null) return "";
+        int q = path.indexOf('?');
+        if (q < 0) return "";
+        for (String pair : path.substring(q + 1).split("&")) {
+            int eq = pair.indexOf('=');
+            if (eq < 0 || !pair.substring(0, eq).equals(key)) continue;
+            String v = pair.substring(eq + 1);
+            try {
+                return URLDecoder.decode(v, "UTF-8");
+            } catch (Exception e) {
+                return v;
+            }
+        }
+        return "";
     }
 
-    /** 危险命令：挂起等待用户确认（前台弹窗 / 后台通知），超时默认拒绝 */
+    private boolean confirmEnabled() {
+        return ctx.getSharedPreferences(Constants.PREFS, Context.MODE_PRIVATE)
+                .getBoolean(Constants.KEY_CONFIRM_SHELL, true);
+    }
+
+    /** 危险命令：挂起等待用户确认（弹窗 + 通知），超时默认拒绝 */
     private String awaitConfirm(String cmd) {
         return requestUserConfirm(cmd) ? ShizukuShell.exec(cmd) : "[USER_REJECTED]";
     }
 
-    /** 只请求用户确认（不执行命令），返回是否允许；/confirm 端点用 */
+    /** 只请求用户确认（不执行命令），返回是否允许；/confirm 端点用。
+     *  弹窗与通知同时发：只走弹窗的话，Activity 一被 pause 用户就再也看不见，
+     *  只能干等 60s 超时（这正是"弹窗出现与否不稳定"的由来）。 */
     private boolean requestUserConfirm(String cmd) {
-        if (confirmBusy) return false; // 已有确认在进行：拒绝新的（避免状态覆盖）
-        confirmBusy = true;
+        if (!confirmBusy.compareAndSet(false, true)) {
+            return false; // 已有确认在进行：拒绝新的（避免 pendingLatch 互相覆盖）
+        }
         try {
             CountDownLatch latch = new CountDownLatch(1);
+            // epoch 先递增：上一轮残留的弹窗/通知按钮带的是旧 epoch，会被丢弃，
+            // 不会把授权决定打到这个新请求上。
+            final long myEpoch = confirmEpoch.incrementAndGet();
+            pendingAllow = false;   // 先写标志，再发布 latch
             pendingLatch = latch;
-            pendingAllow = false;
 
-            MainActivity act = MainActivity.current;
+            // 通知是权威渠道（前后台都在），前台再叠一个弹窗当快捷方式
+            showConfirmNotification(cmd, myEpoch);
+            final MainActivity act = MainActivity.current;
             if (act != null) {
-                // 前台：App 内弹窗
                 final String prompt = "模型试图在设备上执行：\n" + cmd + "\n\n是否允许？";
-                act.runOnUiThread(() -> new androidx.appcompat.app.AlertDialog.Builder(act)
-                        .setTitle("DSHA 安全确认")
-                        .setMessage(prompt)
-                        .setPositiveButton("允许", (d, w) -> {
-                            pendingAllow = true;
-                            CountDownLatch l = pendingLatch;
-                            if (l != null) l.countDown();
-                        })
-                        .setNegativeButton("拒绝", (d, w) -> {
-                            CountDownLatch l = pendingLatch;
-                            if (l != null) l.countDown();
-                        })
-                        .setOnCancelListener(d -> {
-                            CountDownLatch l = pendingLatch;
-                            if (l != null) l.countDown();
-                        })
-                        .setOnDismissListener(d -> {
-                            CountDownLatch l = pendingLatch;
-                            if (l != null) l.countDown();
-                        })
-                        .show());
-            } else {
-                // 后台：高优先级通知 + 允许/拒绝按钮
-                showConfirmNotification(cmd);
+                act.runOnUiThread(() -> {
+                    // .show() 在正在 finishing 的 Activity 上会抛 BadTokenException，
+                    // 这里是主线程，异常不在 handle() 的 catch 范围内 → 会崩 App
+                    try {
+                        if (act.isFinishing() || act.isDestroyed()) return;
+                        pendingDialog = new androidx.appcompat.app.AlertDialog.Builder(act)
+                                .setTitle("DSHA 安全确认")
+                                .setMessage(prompt)
+                                // 必须明确选一个：误触关闭不再被当作拒绝。也不要在
+                                // OnDismiss/OnCancel 里 countDown——Activity 被 pause
+                                // 导致的 dismiss 会误判成"用户拒绝"，而用户还能从通知里点。
+                                .setCancelable(false)
+                                .setPositiveButton("允许", (d, w) -> resolveConfirm(true, myEpoch))
+                                .setNegativeButton("拒绝", (d, w) -> resolveConfirm(false, myEpoch))
+                                .show();
+                    } catch (Throwable t) {
+                        android.util.Log.w(TAG, "确认弹窗弹出失败，仍可从通知确认：" + t);
+                    }
+                });
+            } else if (!notificationsEnabled()) {
+                // 后台 + 通知被拒 = 用户看不到任何提示，只能干等 60s 超时被拒。
+                // 至少留下日志，别让这变成无从排查的"命令莫名被拒"。
+                android.util.Log.w(TAG, "无前台界面且通知权限被拒，确认必然超时拒绝：" + cmd);
             }
 
             try {
                 boolean finished = latch.await(CONFIRM_TIMEOUT_S, TimeUnit.SECONDS);
-                pendingLatch = null;
-                if (!finished) {
-                    cancelConfirmNotification();
-                    return false;
-                }
-                return pendingAllow;
+                return finished && pendingAllow;
             } catch (InterruptedException e) {
-                pendingLatch = null;
                 return false;
             }
         } finally {
-            confirmBusy = false;
+            // 顺序要紧：清理必须全部做完，最后才放开 confirmBusy。
+            // 反过来的话，下一个请求会在这之前抢进来发新通知，而
+            // cancelConfirmNotification() 用的是固定通知 ID，会把它刚发的通知取消掉。
             pendingLatch = null;
+            dismissConfirmDialog();
             cancelConfirmNotification();
+            confirmBusy.set(false);
         }
     }
 
-    /** 通知按钮回调（ConfirmReceiver） */
-    public void resolveConfirm(boolean allow) {
-        pendingAllow = allow;
+    private boolean notificationsEnabled() {
+        try {
+            NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+            // framework API 24+，比运行时权限检查更准（用户在设置里关掉通知也算）
+            return nm == null || nm.areNotificationsEnabled();
+        } catch (Throwable e) {
+            return true; // 判断不了就别妄下结论
+        }
+    }
+
+    /** 通知按钮（ConfirmReceiver）与前台弹窗按钮共用的回调。
+     *  epoch 校验 + latch 认领：丢弃迟到的、属于上一个请求的点击。 */
+    public void resolveConfirm(boolean allow, long epoch) {
+        if (epoch != confirmEpoch.get()) {
+            android.util.Log.i(TAG, "忽略过期的确认点击（epoch " + epoch + "）");
+            return;
+        }
         CountDownLatch l = pendingLatch;
-        if (l != null) l.countDown();
+        if (l == null || l.getCount() == 0) return; // 已决或无挂起
+        pendingAllow = allow;
+        l.countDown();
+        dismissConfirmDialog();
         cancelConfirmNotification();
     }
 
-    private void showConfirmNotification(String cmd) {
+    /** 关掉挂起的弹窗：setCancelable(false) 让它自己关不掉，确认完成后必须主动 dismiss，
+     *  否则它会滞留在屏幕上，用户后来点它就把授权打到下一个请求上了。
+     *  先把引用摘到局部变量再置 null，这样即使下一个请求已设好新弹窗也不会误关它。 */
+    private void dismissConfirmDialog() {
+        final androidx.appcompat.app.AlertDialog d = pendingDialog;
+        if (d == null) return;
+        pendingDialog = null;
+        try {
+            new android.os.Handler(android.os.Looper.getMainLooper()).post(() -> {
+                try {
+                    if (d.isShowing()) d.dismiss();
+                } catch (Throwable ignored) {
+                }
+            });
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private void showConfirmNotification(String cmd, long epoch) {
         createConfirmChannel();
         String shortCmd = cmd.length() > 100 ? cmd.substring(0, 100) + "…" : cmd;
-        Intent allowI = new Intent(ctx, ConfirmReceiver.class).setAction(ConfirmReceiver.ACTION_ALLOW);
-        Intent denyI = new Intent(ctx, ConfirmReceiver.class).setAction(ConfirmReceiver.ACTION_DENY);
-        PendingIntent allowPi = PendingIntent.getBroadcast(ctx, 31, allowI,
+        Intent allowI = new Intent(ctx, ConfirmReceiver.class).setAction(ConfirmReceiver.ACTION_ALLOW)
+                .putExtra(ConfirmReceiver.EXTRA_EPOCH, epoch);
+        Intent denyI = new Intent(ctx, ConfirmReceiver.class).setAction(ConfirmReceiver.ACTION_DENY)
+                .putExtra(ConfirmReceiver.EXTRA_EPOCH, epoch);
+        // requestCode 必须随 epoch 变化：固定 code + FLAG_UPDATE_CURRENT 会把旧
+        // PendingIntent 的 extras 覆盖成新 epoch，残留通知的按钮照样能打到新请求上。
+        int base = (int) (epoch & 0x3FFFFFFFL) * 2;
+        PendingIntent allowPi = PendingIntent.getBroadcast(ctx, base, allowI,
                 PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
-        PendingIntent denyPi = PendingIntent.getBroadcast(ctx, 32, denyI,
+        PendingIntent denyPi = PendingIntent.getBroadcast(ctx, base + 1, denyI,
                 PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         Notification n = new NotificationCompat.Builder(ctx, CONFIRM_CHANNEL)
                 .setSmallIcon(R.drawable.ic_launch)
@@ -313,8 +509,12 @@ public final class HttpShellService {
         }
     }
 
-    private static String jsonEscape(String s) {
-        StringBuilder sb = new StringBuilder();
+    /** 转成合法 JSON 字符串（含外层双引号）。
+     *  原实现只转义、不加引号，输出 {"result":YES} 并不是合法 JSON——
+     *  用 JSON 解析器的客户端会解析失败、走异常分支放行，确认因此形同虚设。 */
+    private static String jsonQuote(String s) {
+        StringBuilder sb = new StringBuilder(s.length() + 2);
+        sb.append('"');
         for (char ch : s.toCharArray()) {
             switch (ch) {
                 case '"': sb.append("\\\""); break;
@@ -327,6 +527,7 @@ public final class HttpShellService {
                     else sb.append(ch);
             }
         }
+        sb.append('"');
         return sb.toString();
     }
 }

--- a/app/src/main/res/layout/fragment_config.xml
+++ b/app/src/main/res/layout/fragment_config.xml
@@ -94,6 +94,15 @@
             android:layout_marginTop="16dp"
             android:text="危险 Shell 操作需确认（删除/格式化/卸载/重启等）" />
 
+        <TextView
+            android:id="@+id/config_guard_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:layout_marginTop="4dp"
+            android:textSize="12sp"
+            android:visibility="gone" />
+
         <CheckBox
             android:id="@+id/config_check_update"
             android:layout_width="match_parent"


### PR DESCRIPTION
## 背景

用户提交的 bug 报告（`dsha-bug-report.md`）反映两个关联问题：确认弹窗发不出，以及**确认机制完全失效** —— 用户点「拒绝」后命令仍执行成功，任意设备命令（含 `rm`/`reboot`）无需授权即可执行。

逐行审查确认报告现象都能在仓库代码里定位到根因，且比报告推测的更多：**共 15 处缺陷**。其中三个真因报告没能推测到：

| # | 位置 | 缺陷 | 后果 |
|---|---|---|---|
| 1 | `HttpShellService.java` `jsonEscape` | 只转义不加引号，输出 `{"result":YES}` **不是合法 JSON** | JSON 客户端解析失败后走异常分支放行 —— **这才是「点拒绝仍执行」的真因** |
| 2 | accept 循环 | `handle(client)` 同步执行 | 一次 60s 确认阻塞整个桥（解释了实测 `0.028s` vs `3.731s`） |
| 3 | `GUARD_VERSION="8"` vs 脚本 `echo 9` | `equals` 恒假 | **每次 `startWeb` / 开终端都 `rm -rf /root/dsh-bin`** 全量重装守卫，顺带删掉 agent 主通道 `adb-shell` |

第 3 项是「弹窗时有时无」和「主通道时不时消失」的共同诱因。

## 主要修复

### App 侧 `HttpShellService`（唯一真正的强制点）

- **双栈监听** `127.0.0.1` + `::1` —— `getLoopbackAddress()` 在 IPv6-preferred 设备只返回 `::1`，而 rootfs 客户端脚本写死 `127.0.0.1`，确认链路整条断裂
- **合法 JSON** `{"result":"YES"}`（向后兼容：老客户端的 `grep -q YES` 对 `"YES"` 仍匹配）
- **查询参数按 `&` 切分** —— 原来 `indexOf("cmd=")` 取到串尾，把 `&token=xxx` 一起当成命令：弹窗里**泄露 token**，`/exec` 还会把它当后台任务执行
- **`/confirm` 不再用 `DangerShellGuard` 二次过滤** —— 客户端主动来问即已判定需要授权；宿主名单与 rootfs 包装侧正则是两套规则，靠它过滤会让确认被静默跳过（报告 Bug B 的直接原因）。`/exec` 路径语义不变
- **每连接独立工作线程**，确认不再阻塞全桥
- **弹窗与通知同时发**，任一响应即解除；移除 `OnDismissListener` 的 `countDown`（Activity 被 pause 导致的 dismiss 不该判成拒绝）
- **每次确认带 epoch 做归属校验** —— 防止残留弹窗/通知按钮把授权打到下一个请求上；`PendingIntent` requestCode 随 epoch 变化
- **跨实例单例守卫** —— `HarnessService` 与 `DeviceBridgeService` 各 `new` 一个实例，第二个绑不上端口时不能把活实例从 `instance` 抹掉，否则通知按钮全废、`stop()` 也关不掉桥
- `confirmBusy` 改 `AtomicBoolean`（检查后置位必须原子）；token 文件每次 `start` 校验自愈（rootfs 重建后原本会永久 `UNAUTHORIZED`）
- 新增 `/health` 端点便于诊断；`exec` 返回 null 兜底，避免静默不回响应

### 容器侧（防呆层）

- `dsh-confirm.sh` **补 token**（原来不带 token 一律 `UNAUTHORIZED`，正是用户报的 `USER_REJECTED`）、双地址探测、严格匹配 `"result":"YES"`，桥不可达时打印可诊断原因而非静默拒绝
- `adb-shell.py` **新增确认关卡**：只读白名单免确认，其余先请求 3090，桥不可达/异常一律拒绝执行（fail-closed）。`DSH_INTERNAL=1` 供 App 内部调用跳过
- `AdbBridge.SCRIPT_VERSION` 7→8 强制重注入；`injected()` 的 `contains` 改 `equals`（版本号进两位数会误判已注入而跳过重注入）

### 可观测性

`ensureBashGuardPatch()` 的失败不再静默。该补丁靠 `sed` 匹配 dsh 已构建代码的字面串 `command: request.command`，而 dsh 走「始终最新 RC」自动升级 —— 上游一改代码这层保险就失配。现在四种结果都回传，状态写入 prefs，**配置页常驻展示**，状态变化时提示一次。

## 验证

**已通过：**

- **Bug 1 闭环**：mock 桥回放 8 种响应，`{"result":"YES"}` 放行、`{"result":"NO"}` 拒绝；**旧的畸形 `{"result":YES}` 现在被拒绝**而非放行。Python 客户端 8/8、bash 客户端 5/5 一致
- **Bug 2 实证**：旧解析得到 `'rm -rf /sdcard/x&token=abc123def'`，新解析正确分离命令与 token；参数顺序反转、`%26`/`%3D` 转义、缺 token 均正确
- **只读白名单** 28/28：`cat /etc/hosts` 放行，而 `cat x > /y`、`echo a|sh`、`ls $(rm -rf /)`、`` dumpsys `rm x` ``、`catfish`、`idle` 全部判为需确认
- **状态机穷举**：`owner`/`STARTED` 走完长度 1–5 的全部序列（~3900 条），从不双 owner，`STARTED`/`instance`/端口占用三者始终一致，绑定全失败能复位不卡死
- **守卫补丁四场景**：可 patch → `LIB_PATCHED`、幂等 → `LIB_ALREADY`、**dsh 升级失配 → `PATCH_FAILED`**、lib 缺失 → `NO_LIB`
- 语法层：Python `py_compile`、shell `bash -n`（含 heredoc 内脚本单独抽出检查）、布局 XML 合法且 id 无重复、各文件括号与字面量平衡、`catch` 可达性、常量替换值一致（SharedPreferences key 未变，用户设置不丢）

**未验证（请注意）：**

> **Java 侧未编译。** 提交环境无 JDK / Gradle / Android SDK，且 `app/build.gradle` 要求 `assets/offline-rootfs.*` 存在（该文件不提交）。改动经逐行审查与独立复查，但这不等于编译通过 —— **请以 CI 结果为准**。本次新增了 `R.id.config_guard_status` 引用，需 aapt 生成 `R.java` 后才能解析。

另外：改了 `rootfs-confirm-install.sh` 会命中 CI 的 offline-rootfs 缓存 key（`android-build.yml`），本次构建会重建 rootfs。

## 安全边界说明

`adb-shell.py` 这层确认是**防呆不防坏** —— 容器内 agent 是 root，能改脚本、也能直接调 `adb_shell_wifi` 库绕过包装器。唯一真正的强制点是 App 侧的 3090 桥。本次对两层都修，但不假装容器层是安全边界。若要更强的保证，需在 App 侧拦截命令执行路径。

## 建议的 review 重点

1. `HttpShellService.requestUserConfirm()` / `resolveConfirm()` 的 epoch 归属校验与 `finally` 清理顺序（`confirmBusy.set(false)` 故意放最后 —— `cancelConfirmNotification()` 用固定通知 ID，提前放开门会取消下一个请求刚发的通知）
2. `owner`/`STARTED` 状态机在双 Service 场景下的正确性
3. 未 bump `versionName`/`versionCode` —— 需要的话请告知

## 设备端手测清单（构建后）

1. `/health?token=…` 在 `127.0.0.1` 与 `[::1]` **都**返回 `{"result":"OK"}`
2. `/confirm?cmd=TEST&token=…` **挂起等待**，不再 0.028s 秒回
3. 点「拒绝」→ 命令**不执行**（报告的决定性反例）
4. 确认挂起期间另开 `/health` 要立刻返回
5. 弹窗出现后切后台 → 通知里点「允许」仍生效
6. 弹窗里显示的命令**不含** `&token=`
7. `/root/dsh-bin/adb-shell "echo x > /sdcard/t.txt"` 弹窗，点拒绝 → 文件**不生成**
8. 连续两次 `startWeb` / 开两次终端 → `adb-shell` **不再被删**，`cat /root/dsh-bin/.version` 稳定为 `10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
