### PR TITLE
fix: 修复 PTY 终端显示与输入回显

### DIFF
--- a/app/src/main/java/com/deepseekharness/app/ProotBootstrap.java
+++ b/app/src/main/java/com/deepseekharness/app/ProotBootstrap.java
@@ -280,8 +280,13 @@ public class ProotBootstrap {
     public String[] ptyArgv(String... guestCmd) {
         java.util.List<String> argv = baseProotArgv();
         if (guestCmd == null || guestCmd.length == 0) {
+            // 某些 Android/容器运行时组合创建出来的 PTY 会保留 -echo，表现为输入时
+            // 什么都看不到、回车后命令却照常执行。先在同一个 PTY 上恢复标准模式，
+            // 再 exec 登录 shell；这条准备命令本身不会留下额外的中间进程。
             argv.add("/bin/bash");
-            argv.add("-l");
+            argv.add("-c");
+            argv.add("stty sane 2>/dev/null || stty echo icanon 2>/dev/null || true; "
+                    + "exec /bin/bash -l");
         } else {
             java.util.Collections.addAll(argv, guestCmd);
         }

--- a/app/src/main/res/drawable/bg_terminal.xml
+++ b/app/src/main/res/drawable/bg_terminal.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/terminal_surface" />
+    <corners android:radius="@dimen/radius_card" />
+    <stroke android:width="@dimen/stroke" android:color="@color/terminal_outline" />
+</shape>

--- a/app/src/main/res/layout/fragment_pty_terminal.xml
+++ b/app/src/main/res/layout/fragment_pty_terminal.xml
@@ -68,14 +68,23 @@
             android:textSize="@dimen/text_caption" />
     </LinearLayout>
 
-    <com.termux.view.TerminalView
-        android:id="@+id/pty_view"
+    <!-- TerminalView 自己按整个 View 的宽高绘制字符，不读取 View.padding。
+         用外层容器提供真正的安全边距，避免第一行文字被圆角裁掉。 -->
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:background="@drawable/bg_preview"
-        android:focusable="true"
-        android:focusableInTouchMode="true" />
+        android:background="@drawable/bg_terminal"
+        android:padding="@dimen/gap_tight">
+
+        <com.termux.view.TerminalView
+            android:id="@+id/pty_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/terminal_surface"
+            android:focusable="true"
+            android:focusableInTouchMode="true" />
+    </FrameLayout>
 
     <!-- 扩展键：按钮由代码生成（12 个 TextView 写在 XML 里既长又难统一样式） -->
     <HorizontalScrollView

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -14,6 +14,10 @@
     <color name="warn">#C48A1A</color>
     <color name="err">#C45A5A</color>
     <color name="preview">#F0F3F8</color>
+    <!-- Termux 的默认 ANSI 前景色是白色；终端背景必须固定为深色，不能复用
+         会在浅色主题下变亮的 preview，否则就会出现浅灰底白字。 -->
+    <color name="terminal_surface">#0A0D12</color>
+    <color name="terminal_outline">#263041</color>
     <color name="logo_top">#E8EEF8</color>
     <color name="logo_bot">#D5DFF0</color>
     <!-- 按压涟漪：主色低透明度，浅色底上淡淡一层 -->


### PR DESCRIPTION
## 问题

PTY 终端在部分设备上存在以下显示与交互问题：

- 浅色主题下终端使用浅灰背景，而默认 ANSI 前景色为白色，导致文字难以辨认
- 首行和左侧文字会被终端容器的圆角边缘裁切
- 输入命令时看不到文字，只有按下回车后命令及结果才会显示

## 修改

- 为终端增加独立的固定深色背景和边框颜色
- 使用带安全边距的外层容器，避免终端文字被圆角裁切
- 启动登录 Shell 前执行 `stty sane`，恢复 PTY 的输入回显和标准模式
- 保留系统默认字体，不引入自定义字体资源

## 验证

- [x] 本地离线执行 `:app:assembleDebug`
- [x] 通过 arm64 APK 校验
- [x] 在 PKR110（Android 15）真机安装测试
- [x] 输入内容可在按下回车前正常显示
- [x] 终端边缘文字不再被裁切
- [x] 浅色主题下终端文字清晰可见
- [x] Fork Fast checks 通过
- [x] Fork Android Debug Build 通过