### PR TITLE
feat(ui): 新增快捷抽屉对话弹层 (Activity) 与通知交互，不必返回容器和依赖浏览器

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,30 @@
         android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!-- WifiLock 用：熄屏后 WiFi 会进省电模式，3081 局域网桥与联网安装都会断 -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <!-- 流式悬浮条（把 agent 正在生成的内容显示在屏幕顶部）。
+         默认关闭、需要用户在系统设置里单独授予；不给也只是这一个功能不可用。
+         真正的「状态栏歌词」没有公开接口（只有 Flyme/exTHmUI 认 ticker flag，
+         其余机型要 Xposed），所以走自绘悬浮窗这条免 ROOT 的路。 -->
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+
+    <!-- 位置：让 agent 能回答「我在哪」「附近有什么」这类问题。
+         运行时权限，且 DSHA 侧还有一道开关（cap_location，**默认关**）——
+         位置是能定位到人的信息，不该因为装了 App 就默认开着。
+         标 required=false：没有 GPS 的设备（部分平板）照样能装。 -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-feature
+        android:name="android.hardware.location"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.sensor.light"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera.flash"
+        android:required="false" />
     <!-- ADB 保活：系统休眠会冻结后台网络，加入电池优化白名单后连接才能长期在线。
          一次性弹窗申请（本 App 不上架 Play，不受该权限的商店政策限制）。 -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
@@ -63,6 +86,16 @@
             android:excludeFromRecents="true"
             android:label="ADB 无线配对"
             android:theme="@style/Theme.AppCompat.Dialog" />
+
+        <!-- 快捷对话底部抽屉弹层（点击常驻通知或任务完成通知直达，独立任务栈物理隔离） -->
+        <activity
+            android:name=".QuickChatSheetActivity"
+            android:exported="false"
+            android:taskAffinity="com.dsh.client.quick_sheet"
+            android:excludeFromRecents="true"
+            android:launchMode="singleInstance"
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.DeepseekHarness.SheetTransparent" />
 
         <service
             android:name=".HarnessService"

--- a/app/src/main/java/com/deepseekharness/app/ConfirmReceiver.java
+++ b/app/src/main/java/com/deepseekharness/app/ConfirmReceiver.java
@@ -1,27 +1,220 @@
 package com.deepseekharness.app;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.widget.Toast;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.RemoteInput;
+
+import java.io.File;
 
 /**
- * 后台安全确认通知的按钮接收器：用户点「允许/拒绝」后
- * 通知 HttpShellService 释放挂起的确认。
+ * 后台安全确认、助手提问与任务状态通知的按钮/输入接收器：
+ * - 用户点确认/提问选项或就地输入回复
+ * - 运行中通知点击「🛑 停止任务」紧急制动（向容器注入 cancel 标志并终止活动工具子进程）
+ * - 完成/终止通知就地输入「💬 继续对话/重新输入」继续交流（向容器写入 prompt 指令自动开启新轮次）
  */
 public class ConfirmReceiver extends BroadcastReceiver {
 
     public static final String ACTION_ALLOW = "com.deepseekharness.app.CONFIRM_ALLOW";
     public static final String ACTION_DENY = "com.deepseekharness.app.CONFIRM_DENY";
-    /** 确认序号：由 HttpShellService 校验，过期点击（锁屏残留通知、通知历史、
+    public static final String ACTION_ASK_ANSWER = "com.deepseekharness.app.ASK_ANSWER";
+    public static final String ACTION_ASK_REPLY = "com.deepseekharness.app.ASK_REPLY";
+    public static final String ACTION_TASK_REPLY = "com.deepseekharness.app.TASK_REPLY";
+    public static final String ACTION_STOP_TASK = "com.deepseekharness.app.STOP_TASK";
+
+    /** 确认/提问序号：由 HttpShellService 校验，过期点击（锁屏残留通知、通知历史、
      *  手表转发）会被丢弃，不会误授权给当前请求。（吸收上游 PR#24） */
     public static final String EXTRA_EPOCH = "confirm_epoch";
+    public static final String EXTRA_ANSWER = "ask_answer";
+    public static final String EXTRA_REPLY_TEXT = "ask_reply_text";
+    public static final String EXTRA_TASK_REPLY_TEXT = "task_reply_text";
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        if (intent == null) return;
+        String act = intent.getAction();
+        if (act == null) return;
+
         HttpShellService svc = HttpShellService.instance();
-        if (svc != null) {
-            svc.resolveConfirm(ACTION_ALLOW.equals(intent.getAction()),
-                    intent.getLongExtra(EXTRA_EPOCH, -1L));
+
+        if (ACTION_STOP_TASK.equals(act)) {
+            handleStopTask(context);
+            return;
         }
+
+        if (ACTION_TASK_REPLY.equals(act)) {
+            handleTaskReply(context, intent);
+            return;
+        }
+
+        if (svc != null) {
+            long epoch = intent.getLongExtra(EXTRA_EPOCH, -1L);
+            if (ACTION_ASK_REPLY.equals(act)) {
+                CharSequence cs = null;
+                try {
+                    Bundle result = RemoteInput.getResultsFromIntent(intent);
+                    cs = result != null ? result.getCharSequence(EXTRA_REPLY_TEXT) : null;
+                } catch (Throwable ignored) {}
+                String text = cs != null ? cs.toString().trim() : "";
+                if (!text.isEmpty()) {
+                    svc.resolveAsk(text, epoch);
+                }
+            } else if (ACTION_ASK_ANSWER.equals(act)) {
+                svc.resolveAsk(intent.getStringExtra(EXTRA_ANSWER), epoch);
+            } else if (ACTION_ALLOW.equals(act)) {
+                svc.resolveConfirm(true, epoch);
+            } else if (ACTION_DENY.equals(act)) {
+                svc.resolveConfirm(false, epoch);
+            }
+        }
+    }
+
+    private void handleStopTask(Context ctx) {
+        // 1. 取消运行中实时状态通知
+        NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm != null) {
+            nm.cancel(Constants.NOTIF_TASK_RUNNING);
+        }
+
+        // 2. 立即注销清理租约文件，关闭设备操作权限；同时通知 DSH 插件停止 Agent 工作并杀掉活动的工具命令
+        try {
+            HarnessController hc = HarnessController.get(ctx);
+            if (hc != null && hc.getProot() != null && hc.getProot().getRootfsDir() != null) {
+                File dshDir = new File(hc.getProot().getRootfsDir(), "root/.dsh");
+                if (!dshDir.exists()) dshDir.mkdirs();
+
+                File lf = new File(dshDir, ".auth_lease");
+                if (lf.exists()) lf.delete();
+
+                // 创建取消请求标志文件，由 dsh-task-notifier 插件调用 agent.cancel()
+                File cancelFlag = new File(dshDir, ".cancel_requested");
+                cancelFlag.createNewFile();
+
+                // 强制中止容器内可能正在阻塞运行的外部命令（如长命令 bash/python/curl）
+                new Thread(() -> {
+                    try {
+                        hc.getProot().execAndRead("killall -9 bash python3 2>/dev/null || true");
+                    } catch (Throwable ignored) {}
+                }, "stop-task-kill").start();
+            }
+        } catch (Throwable ignored) {}
+
+        // 3. 震动反馈 150ms
+        try {
+            android.os.Vibrator v;
+            if (Build.VERSION.SDK_INT >= 31) {
+                android.os.VibratorManager vm =
+                        (android.os.VibratorManager) ctx.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
+                v = vm == null ? null : vm.getDefaultVibrator();
+            } else {
+                v = (android.os.Vibrator) ctx.getSystemService(Context.VIBRATOR_SERVICE);
+            }
+            if (v != null) {
+                v.vibrate(android.os.VibrationEffect.createOneShot(150, android.os.VibrationEffect.DEFAULT_AMPLITUDE));
+            }
+        } catch (Throwable ignored) {}
+
+        // 4. 先走通知：发送「任务已终止」通知写入「任务结果与交互」独立通道（带 RemoteInput 重新输入框）
+        showStoppedNotification(ctx);
+
+        // 5. 再走 Toast 提示
+        new Handler(Looper.getMainLooper()).post(() -> {
+            try {
+                Toast.makeText(ctx, "⚠️ 智能体任务已被用户紧急终止", Toast.LENGTH_SHORT).show();
+            } catch (Throwable ignored) {}
+        });
+    }
+
+    private void handleTaskReply(Context ctx, Intent intent) {
+        CharSequence cs = null;
+        try {
+            Bundle result = RemoteInput.getResultsFromIntent(intent);
+            cs = result != null ? result.getCharSequence(EXTRA_TASK_REPLY_TEXT) : null;
+        } catch (Throwable ignored) {}
+        final String text = cs != null ? cs.toString().trim() : "";
+        if (text.isEmpty()) return;
+
+        // 1. 取消已完成/已终止通知
+        NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm != null) {
+            nm.cancel(Constants.NOTIF_TASK);
+            nm.cancel(Constants.NOTIF_TASK_STOPPED);
+        }
+
+        // 2. 将待发送指令写入容器 pending_prompt，由 dsh-task-notifier 插件自动注入 DSH 开启新轮次
+        try {
+            HarnessController hc = HarnessController.get(ctx);
+            if (hc != null && hc.getProot() != null && hc.getProot().getRootfsDir() != null) {
+                File dshDir = new File(hc.getProot().getRootfsDir(), "root/.dsh");
+                if (!dshDir.exists()) dshDir.mkdirs();
+                File promptFile = new File(dshDir, ".pending_prompt");
+                java.nio.file.Files.write(promptFile.toPath(),
+                        text.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            }
+        } catch (Throwable ignored) {}
+
+        // 3. Toast 提示收到新指令
+        new Handler(Looper.getMainLooper()).post(() -> {
+            try {
+                Toast.makeText(ctx, "✓ 收到新指令：" + (text.length() > 20 ? text.substring(0, 20) + "…" : text), Toast.LENGTH_SHORT).show();
+            } catch (Throwable ignored) {}
+        });
+
+        // 4. 打开 App 首页以展示并继续执行会话
+        try {
+            Intent openIntent = new Intent(ctx, MainActivity.class)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    .putExtra("dsh_reply_text", text);
+            ctx.startActivity(openIntent);
+        } catch (Throwable ignored) {}
+    }
+
+    private void showStoppedNotification(Context ctx) {
+        if (Build.VERSION.SDK_INT >= 26) {
+            NotificationChannel ch = new NotificationChannel(
+                    Constants.CHANNEL_TASK_RESULT, "任务结果与交互",
+                    NotificationManager.IMPORTANCE_HIGH);
+            ch.setDescription("智能体任务完成、异常结束或终止时的结果通知");
+            NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (nm != null) nm.createNotificationChannel(ch);
+        }
+
+        Intent openAppIntent = new Intent(ctx, QuickChatSheetActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent contentPi = PendingIntent.getActivity(ctx, 201, openAppIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+        // 点击「💬 重新开始」直接从屏幕底部唤起抽屉弹层
+        Intent actionIntent = new Intent(ctx, QuickChatSheetActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent actionPi = PendingIntent.getActivity(ctx, 202, actionIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+        NotificationCompat.Action replyAction = new NotificationCompat.Action.Builder(
+                R.drawable.ic_launch, "💬 重新开始", actionPi)
+                .build();
+
+        NotificationCompat.Builder nb = new NotificationCompat.Builder(ctx, Constants.CHANNEL_TASK_RESULT)
+                .setSmallIcon(R.drawable.ic_launch)
+                .setContentTitle("⚠️ DSHA · 任务已终止")
+                .setContentText("已按指令停止操作。点击查看或继续对话。")
+                .setStyle(new NotificationCompat.BigTextStyle().bigText("已按指令停止操作。点击查看或继续对话。"))
+                .setContentIntent(contentPi)
+                .addAction(replyAction)
+                .setAutoCancel(true)
+                .setPriority(NotificationCompat.PRIORITY_HIGH);
+
+        NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm != null) nm.notify(Constants.NOTIF_TASK_STOPPED, nb.build());
     }
 }

--- a/app/src/main/java/com/deepseekharness/app/HarnessService.java
+++ b/app/src/main/java/com/deepseekharness/app/HarnessService.java
@@ -84,6 +84,14 @@ public class HarnessService extends Service {
         if (intent != null && ACTION_STOP.equals(intent.getAction())) {
             c.stopWeb();
             stopKeepAlive();
+            // 设备桥（127.0.0.1:3090）也一起停 —— 它是独立的后台服务，不跟着前台服务走。
+            // 「停止」在用户眼里就是全停：留个监听端口在那儿既费电，也会让覆盖安装时系统
+            // 多一个要终止的目标（装 391MB 包时那正是 Session destroyed 的诱因之一，
+            // 所以装新包前点一下通知栏这个「停止」就够，不必再去设置页找入口）。
+            try {
+                stopService(new Intent(this, DeviceBridgeService.class));
+            } catch (Throwable ignored) {
+            }
             stopForeground(true);
             stopSelf();
             return START_NOT_STICKY;
@@ -92,6 +100,12 @@ public class HarnessService extends Service {
             // 软重启：深停 → 等端口关透 → 重新拉起（不再杀 App 进程「闪退」重启）
             c.restartWeb();
             startKeepAlive();
+            return START_STICKY;
+        }
+        // intent 为 null = 系统因 START_STICKY 把服务重建了。这时若用户此前明确停过，
+        // 就不该再拉起 Web —— 否则他永远停不掉，只剩「强制停止」这一条路。
+        // 前台服务壳留着（保持通知与后续可点启动），但不碰 Web 与保活。
+        if (intent == null && !c.shouldAutoStartWeb("服务被系统重建")) {
             return START_STICKY;
         }
         startWeb();
@@ -104,8 +118,83 @@ public class HarnessService extends Service {
     }
 
     /** 启动保活监听：TCP 探测 WebUI 端口，连续失联自动重启（带冷却防风暴） */
+    /** 息屏保活用的两把锁。 */
+    private android.os.PowerManager.WakeLock wakeLock;
+    private android.net.wifi.WifiManager.WifiLock wifiLock;
+
+    /** ADB 后台加固每个进程只做一次（命令幂等，但起 python + adb 有几秒开销）。 */
+    private static final java.util.concurrent.atomic.AtomicBoolean hardenedOnce =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
+
+    /**
+     * 息屏保活：拿 {@code PARTIAL_WAKE_LOCK} 让 CPU 不随熄屏休眠。
+     *
+     * <p><b>WAKE_LOCK 权限在清单里声明了很久，但全树一直没有任何地方真正获取过 WakeLock。</b>
+     * 后果是熄屏之后 CPU 进休眠，容器里的 node 被冻结，WebUI 自然失联；更糟的是保活线程
+     * 自己也睡在 {@code Thread.sleep} 上、同样被冻住，连「发现失联再拉起」都做不到 ——
+     * 于是熄屏一会儿回来，什么都停了。这是「息屏跑不住」最直接的一环。
+     *
+     * <p>顺带拿 WifiLock：熄屏后 WiFi 会进省电模式，3081 局域网桥与联网安装都会断。
+     * {@code WIFI_MODE_FULL_HIGH_PERF} 在 Android 12+ 标了弃用但仍然生效，
+     * 没有等价替代，所以照用。
+     *
+     * <p>代价是耗电，做成可关（{@code keepalive_wakelock}，默认开 —— 装 DSHA 本来就是
+     * 要它在后台跑）。释放跟着 {@link #stopKeepAlive()} 走，与前台服务同生命周期。
+     */
+    private void acquireLocks() {
+        try {
+            if (!getSharedPreferences("deepseekharness", MODE_PRIVATE)
+                    .getBoolean("keepalive_wakelock", true)) {
+                return;
+            }
+            android.os.PowerManager pm =
+                    (android.os.PowerManager) getSystemService(POWER_SERVICE);
+            if (pm != null && (wakeLock == null || !wakeLock.isHeld())) {
+                wakeLock = pm.newWakeLock(android.os.PowerManager.PARTIAL_WAKE_LOCK, "DSHA:web");
+                wakeLock.setReferenceCounted(false);
+                wakeLock.acquire();
+                android.util.Log.i("DSHA", "[保活] 已持有 PARTIAL_WAKE_LOCK");
+            }
+            android.net.wifi.WifiManager wm = (android.net.wifi.WifiManager)
+                    getApplicationContext().getSystemService(WIFI_SERVICE);
+            if (wm != null && (wifiLock == null || !wifiLock.isHeld())) {
+                wifiLock = wm.createWifiLock(
+                        android.net.wifi.WifiManager.WIFI_MODE_FULL_HIGH_PERF, "DSHA:wifi");
+                wifiLock.setReferenceCounted(false);
+                wifiLock.acquire();
+            }
+        } catch (Throwable t) {
+            android.util.Log.w("DSHA", "[保活] 取锁失败（不致命，继续跑）: " + t);
+        }
+    }
+
+    private void releaseLocks() {
+        try {
+            if (wakeLock != null && wakeLock.isHeld()) wakeLock.release();
+        } catch (Throwable ignored) {
+        }
+        try {
+            if (wifiLock != null && wifiLock.isHeld()) wifiLock.release();
+        } catch (Throwable ignored) {
+        }
+        wakeLock = null;
+        wifiLock = null;
+    }
+
     private void startKeepAlive() {
         stopKeepAlive();
+        acquireLocks();
+        // 顺手用 ADB 通道开一次后台白名单（Doze + appops）。幂等，所以每个进程只跑一次；
+        // 异步跑是因为它要在容器里起 python + adb，几秒级，不能拖住前台服务的启动路径。
+        // ADB 没接上时 hardenBackground 自己会跳过。
+        if (hardenedOnce.compareAndSet(false, true)) {
+            new Thread(() -> {
+                try {
+                    c.hardenBackground();
+                } catch (Throwable ignored) {
+                }
+            }, "dsha-harden").start();
+        }
         keepAliveRunning = true;
         keepAliveThread = new Thread(() -> {
             int fail = 0;
@@ -134,10 +223,8 @@ public class HarnessService extends Service {
                 if (fail < KEEPALIVE_MAX_FAIL) continue;
                 fail = 0;
                 long now = System.currentTimeMillis();
-                if (c.isKeepAlivePaused() || HarnessController.isHealingSession()) {
-                    // 用户手动停止过、或会话自愈进行中：不自动拉起（防止边修边写）
-                    continue;
-                }
+                // 手动停止 / 会话自愈 / 刚停过的冷却期，统一判据在 shouldAutoStartWeb
+                if (!c.shouldAutoStartWeb("保活")) continue;
                 if (now - lastRestartAt.get() < RESTART_COOLDOWN_MS) continue; // 冷却期，等它自己缓过来
                 lastRestartAt.set(now);
                 if (restarting.compareAndSet(false, true)) {
@@ -156,6 +243,7 @@ public class HarnessService extends Service {
     }
 
     private void stopKeepAlive() {
+        releaseLocks();
         keepAliveRunning = false;
         if (keepAliveThread != null) {
             keepAliveThread.interrupt();
@@ -214,7 +302,9 @@ public class HarnessService extends Service {
     }
 
     private Notification buildNotification(String title, String text) {
-        Intent intent = new Intent(this, MainActivity.class);
+        // 点击常驻通知直接从屏幕底部弹出快捷对话抽屉（REORDER_TO_FRONT 唤醒常驻单例，避免销毁）
+        Intent intent = new Intent(this, QuickChatSheetActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         PendingIntent pi = PendingIntent.getActivity(this, 0, intent,
                 PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         Intent stop = new Intent(this, HarnessService.class).setAction(ACTION_STOP);

--- a/app/src/main/java/com/deepseekharness/app/HttpShellService.java
+++ b/app/src/main/java/com/deepseekharness/app/HttpShellService.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.widget.Toast;
 
 import androidx.core.app.NotificationCompat;
 
@@ -52,6 +53,15 @@ public final class HttpShellService {
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private volatile CountDownLatch pendingLatch;
     private volatile boolean pendingAllow;
+    /** 本轮确认是否已被认领：三条渠道（通知 / 弹窗 / 悬浮条）谁先点谁生效。
+     *
+     *  <p>没有它的时候，「检查 latch 未决 → 写 pendingAllow → countDown」这三步不是原子的：
+     *  两条渠道几乎同时被点（悬浮条点了没反应又去点通知，或纯误触），两个线程都能通过
+     *  {@code getCount() == 0} 的检查，于是后到的那个会把 pendingAllow 覆盖掉 ——
+     *  等待线程读到的是后写入的值。表现是<b>授权语义反转</b>：点「允许」却被拒绝，
+     *  更糟的是点「拒绝」而另一条渠道的「允许」后到，命令照样执行。 */
+    private final java.util.concurrent.atomic.AtomicBoolean confirmResolved =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
     /** 确认进行中标志：并发确认请求直接拒绝（避免 latch 覆盖导致"点了允许却拒绝"）。
      *  用 AtomicBoolean 而非 volatile boolean —— "检查后置位"必须原子，
      *  否则两个请求线程可能同时通过检查、互相覆盖 pendingLatch。（吸收上游 PR#24） */
@@ -64,10 +74,16 @@ public final class HttpShellService {
             new java.util.concurrent.atomic.AtomicLong();
     /** 当前挂起的弹窗：setCancelable(false) 后它自己关不掉，确认完必须主动 dismiss */
     private volatile androidx.appcompat.app.AlertDialog pendingDialog;
-    /** /app/ask 的一次性问答状态（同一时刻只允许一个提问在等待） */
-    private volatile CountDownLatch askLatch;
+    /** /app/ask 的一次性问答状态（支持前台弹窗与通知栏快捷按钮双通道同步回答）。 */
+    private final java.util.concurrent.atomic.AtomicLong askEpoch =
+            new java.util.concurrent.atomic.AtomicLong();
+    private volatile androidx.appcompat.app.AlertDialog pendingAskDialog;
+    private volatile CountDownLatch pendingAskLatch;
+    private final java.util.concurrent.atomic.AtomicBoolean askResolved =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
     private volatile String askAnswer = "";
-    private volatile boolean askBusy = false;
+    private final java.util.concurrent.atomic.AtomicBoolean askBusy =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
 
     private ServerSocket server;
     /** IPv6 回环监听（兼容脚本用 localhost 解析成 ::1 的场景；绑不上则忽略） */
@@ -89,9 +105,29 @@ public final class HttpShellService {
         return instance;
     }
 
+    /** 桥还没启动过时的兜底 Context。
+     *
+     *  <p>{@link #tokenFileIfPossible()} 原先只从 {@code instance().ctx} 取 Context，
+     *  于是桥没启动过时（比如用户把「设备桥」和「悬浮条」都关着）它返回 null，
+     *  {@link #ensureToken()} 只改内存、**静默不写文件**。自检因此谎报「已重新写入」，
+     *  而容器侧 selftest 同时报「缺 .bridge_token」—— 两份报告自相矛盾，真机上出现过。 */
+    private static volatile Context tokenCtx;
+
+    /** 自检、恢复备份这类在桥启动前就要对齐 token 的场合，先把 Context 交给它。 */
+    static void bindTokenContext(Context ctx) {
+        if (ctx != null) tokenCtx = ctx.getApplicationContext();
+    }
+
     private static java.io.File tokenFileIfPossible() {
+        Context c = null;
         try {
-            HarnessController hc = HarnessController.get(instance().ctx);
+            c = instance().ctx;
+        } catch (Throwable ignored) {
+        }
+        if (c == null) c = tokenCtx;
+        if (c == null) return null;
+        try {
+            HarnessController hc = HarnessController.get(c);
             if (hc != null && hc.getProot() != null && hc.getProot().getRootfsDir() != null) {
                 return new java.io.File(hc.getProot().getRootfsDir(), "root/.dsh/.bridge_token");
             }
@@ -242,7 +278,12 @@ public final class HttpShellService {
         while (running) {
             try {
                 Socket client = ss.accept();
-                client.setSoTimeout(120_000);
+                // 读超时 15 秒（原来 120 秒）。这个超时只管「读请求头」这一段 ——
+                // 命令执行与等用户点确认期间并不 read，不受影响。
+                // 而池子只有 4 个线程：同一台手机上任何 App 都能连 loopback，
+                // 4 个「连上不说话」的连接就能让桥停摆两分钟，agent 的确认弹窗和
+                // 命令全部超时。请求头 15 秒到不齐的客户端本来也不正常。
+                client.setSoTimeout(15_000);
                 java.util.concurrent.ExecutorService p = pool;
                 if (p == null) {
                     try { client.close(); } catch (IOException ignored) { }
@@ -294,20 +335,42 @@ public final class HttpShellService {
         }
     }
 
-    private static boolean tokenMatch(String presented) {
-        String token = authToken.isEmpty() ? ensureToken() : authToken;
-        return token != null && !token.isEmpty() && constantTimeEquals(token, presented);
+    /** 自检用：当前内存里的桥 token 快照（空串 = 桥还没起来过）。
+     *  故意不触发生成 —— 自检本身不该有副作用，写文件那是
+     *  {@link #resetTokenAfterRestore()} 的活儿。 */
+    static String tokenSnapshot() {
+        return authToken == null ? "" : authToken;
     }
 
-    private static boolean constantTimeEquals(String a, String b) {
-        if (a == null || b == null) return false;
-        int diff = a.length() ^ b.length();
-        for (int i = 0; i < a.length(); i++) {
-            char ca = a.charAt(i);
-            char cb = i < b.length() ? b.charAt(i) : 0;
-            diff |= ca ^ cb;
+    /** 恢复备份后重新对齐 3090 桥的 token。
+     *
+     *  <p>老备份包里带着**备份那台机器**的 {@code .dsh/.bridge_token}（新版备份已经把它
+     *  排除了）。恢复出来之后 rootfs 里是旧 token，而 App 进程内的 {@link #authToken}
+     *  还是当前那个 —— 它是静态字段，{@link #ensureToken()} 只在缓存为空时才读文件。
+     *  于是 App 用自己的 token 拼 WebView 首帧 URL，dsh 后端却按恢复出来的旧 token 校验，
+     *  用户看到的就是「DSHA：需要 token，请在 DSHA 应用内打开，或在 URL 后加 ?dsha_t=…」。
+     *
+     *  <p>处理：删掉恢复出来的 token 文件、清空内存缓存，再让 ensureToken 重新生成并写回，
+     *  两侧重新对齐。dsh 后端自己也缓存了 token（webserver-auth-patch 里的
+     *  {@code __dshaTokenCache}），所以要重启 Web 才彻底生效 —— 恢复流程本来就提示重启。 */
+    public static void resetTokenAfterRestore() {
+        try {
+            java.io.File tf = tokenFileIfPossible();
+            if (tf != null && tf.isFile()) {
+                //noinspection ResultOfMethodCallIgnored
+                tf.delete();
+            }
+            authToken = "";
+            ensureToken();
+            android.util.Log.i("DSHA", "恢复后已重置 3090 桥 token（老备份里带的是别的机器的）");
+        } catch (Throwable e) {
+            android.util.Log.w("DSHA", "恢复后重置桥 token 失败: " + e);
         }
-        return diff == 0;
+    }
+
+    private static boolean tokenMatch(String presented) {
+        String token = authToken.isEmpty() ? ensureToken() : authToken;
+        return token != null && !token.isEmpty() && LanAuth.constantTimeEquals(token, presented);
     }
 
     private void handle(Socket client) {
@@ -319,36 +382,35 @@ public final class HttpShellService {
             String path = parts.length > 1 ? parts[1] : "/";
             String cmd = "";
             if (path.startsWith("/exec") || path.startsWith("/confirm")) {
-                int q = path.indexOf("cmd=");
-                if (q >= 0) {
-                    // 关键：cmd= 值要截断到 &（查询串可能有多个参数，如
-                    // /exec?cmd=ls&token=xxx）。旧实现 substring(q+4) 取到末尾，
-                    // cmd 会变成 "ls&token=xxx" → 执行错命令！
-                    String cv = path.substring(q + 4);
-                    int amp = cv.indexOf('&');
-                    if (amp >= 0) cv = cv.substring(0, amp);
-                    cmd = URLDecoder.decode(cv, "UTF-8");
-                }
+                // 走统一的查询串解析（Query.param）：值要截断到 &，参数名要精确匹配。
+                // 旧实现是 path.indexOf("cmd=") —— 值截断修过了，但参数名边界一直没有，
+                // 于是 ?xcmd=junk&cmd=真命令 会取到 junk。/confirm 的 cmd 是<b>给用户看的
+                // 命令原文</b>，取错就等于让用户批准了一条与实际不符的命令。
+                cmd = getParam(queryOf(path), "cmd", "");
             }
             // 鉴权：token 必须匹配（通过 ?token= 或 X-Token header）
             boolean authed = false;
             String t = "";
-            // 只认 query 中的 token（EXCLUSIVE：跳过 path 其他位置的 token=）
-            int qm = path.indexOf('?');
-            String query = qm >= 0 ? path.substring(qm + 1) : "";
-            int tq = query.indexOf("token=");
-            if (tq >= 0) {
-                t = query.substring(tq + 6);
-                int amp = t.indexOf('&');
-                if (amp >= 0) t = t.substring(0, amp);
-                try { t = URLDecoder.decode(t, "UTF-8"); } catch (Exception ignored) { }
-                if (!t.isEmpty()) authed = tokenMatch(t.trim());
+            // 解析与 LanProxyService 共用 LanAuth 那一份。原来这里是
+            // query.indexOf("token=")，没有参数名边界：?xtoken=junk&token=真值
+            // 会先命中 xtoken= 取到 junk 而误拒。两处各写一套判断正是本项目
+            // 反复栽的模式，合并后由 tools/pure-logic-test.sh 一起覆盖。
+            String qt = LanAuth.queryTokenFromTarget(path);
+            if (qt != null && !qt.isEmpty()) {
+                try { qt = URLDecoder.decode(qt, "UTF-8"); } catch (Exception ignored) { }
+                t = qt;
+                authed = tokenMatch(qt.trim());
             }
             if (!authed) {
                 // 也支持 header 传 token（agent 引导用 curl -H）
                 try {
                     String hdr;
+                    int lines = 0;
                     while ((hdr = reader.readLine()) != null && !hdr.isEmpty()) {
+                        // 桥绑在 loopback，但同一台手机上任何 App 都能连 loopback。
+                        // 池子只有 4 个线程 —— 不设上限的话，一个只管发头不发空行的
+                        // 连接就能占住一个线程直到读超时。行数封顶 + 下面的读超时兜底。
+                        if (++lines > 64) break;
                         if (hdr.toLowerCase().startsWith("x-token:")) {
                             String hv = hdr.substring(8).trim();
                             if (!hv.isEmpty() && tokenMatch(hv)) authed = true;
@@ -361,6 +423,10 @@ public final class HttpShellService {
             String result;
             if (!authed) {
                 result = "[UNAUTHORIZED]";
+            } else if (path.startsWith("/app/task/running")) {
+                result = appTaskRunning(path);
+            } else if (path.startsWith("/app/task/cancel")) {
+                result = appTaskCancel();
             } else if (path.startsWith("/app/notify")) {
                 // agent 通过 App 发通知栏提醒（App 层交互）
                 result = appNotify(path);
@@ -390,6 +456,26 @@ public final class HttpShellService {
                 result = appVibrate(path);
             } else if (path.startsWith("/app/ask")) {
                 result = appAsk(path);
+            } else if (path.startsWith("/app/version")) {
+                result = appVersion();
+            } else if (path.startsWith("/app/help")) {
+                result = appHelp();
+            } else if (path.startsWith("/app/plugins")) {
+                result = appPlugins(path);
+            } else if (path.startsWith("/app/overlay")) {
+                result = appOverlay(path);
+            } else if (path.startsWith("/app/location")) {
+                // 位置 / 传感器 / 手电：手机相对服务器真正独有的那几样能力。
+                // 顺序要紧 —— /app/sensors 必须在 /app/sensor 之前判，
+                // 否则 startsWith 会让「列表」被「读单个」抢走。
+                result = DeviceSense.location(ctx, "1".equals(getParam(queryOf(path), "fresh", "")));
+            } else if (path.startsWith("/app/sensors")) {
+                result = DeviceSense.sensorList(ctx);
+            } else if (path.startsWith("/app/sensor")) {
+                result = DeviceSense.sensorRead(ctx, getParam(queryOf(path), "name", "light"));
+            } else if (path.startsWith("/app/torch")) {
+                String on = getParam(queryOf(path), "on", "1");
+                result = DeviceSense.torch(ctx, !"0".equals(on) && !"off".equalsIgnoreCase(on));
             } else if (path.startsWith("/app/export")) {
                 result = appExport(path);
             } else if (cmd.isEmpty()) {
@@ -427,29 +513,60 @@ public final class HttpShellService {
     /** /app/notify?title=&text= ：发通知栏提醒 */
     private String appNotify(String path) {
         try {
-            // App 前台时不发通知（用户正看着页面，不打扰）——与 TaskNotifier 抑制一致
-            if (TaskNotifier.appInForeground) return "FOREGROUND_SKIP";
             String q = queryOf(path);
             String title = getParam(q, "title", "DSHA 通知");
             String text = getParam(q, "text", "");
             if (text.isEmpty()) return "NO_TEXT";
+
+            // 任务结束，清除运行中状态通知
+            cancelRunningNotification();
+
+            // 1. 先走通知：写入「任务结果与交互」独立通道，挂载 RemoteInput 继续对话输入组件
             NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
-            if (nm == null) return "NO_SERVICE";
-            if (Build.VERSION.SDK_INT >= 26) {
-                NotificationChannel ch = new NotificationChannel(
-                        "dsh_agent_channel", "Agent 通知",
-                        NotificationManager.IMPORTANCE_HIGH);
-                ch.setDescription("智能体通过 App 发送的通知");
-                nm.createNotificationChannel(ch);
+            if (nm != null) {
+                if (Build.VERSION.SDK_INT >= 26) {
+                    NotificationChannel ch = new NotificationChannel(
+                            Constants.CHANNEL_TASK_RESULT, "任务结果与交互",
+                            NotificationManager.IMPORTANCE_HIGH);
+                    ch.setDescription("智能体任务完成、异常结束或终止时的结果通知");
+                    nm.createNotificationChannel(ch);
+                }
+
+                Intent openAppIntent = new Intent(ctx, QuickChatSheetActivity.class)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                PendingIntent contentPi = PendingIntent.getActivity(ctx, 20, openAppIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+                // 点击「💬 继续对话」直接从屏幕底部唤起抽屉弹层
+                Intent actionIntent = new Intent(ctx, QuickChatSheetActivity.class)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                PendingIntent actionPi = PendingIntent.getActivity(ctx, 25, actionIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+                NotificationCompat.Action replyAction = new NotificationCompat.Action.Builder(
+                        R.drawable.ic_launch, "💬 继续对话", actionPi)
+                        .build();
+
+                NotificationCompat.Builder b = new NotificationCompat.Builder(ctx, Constants.CHANNEL_TASK_RESULT)
+                        .setSmallIcon(R.drawable.ic_launch)
+                        .setContentTitle(title)
+                        .setContentText(text)
+                        .setStyle(new NotificationCompat.BigTextStyle().bigText(text))
+                        .setContentIntent(contentPi)
+                        .addAction(replyAction)
+                        .setPriority(NotificationCompat.PRIORITY_HIGH)
+                        .setAutoCancel(true);
+                nm.notify(Constants.NOTIF_TASK, b.build());
             }
-            NotificationCompat.Builder b = new NotificationCompat.Builder(ctx, "dsh_agent_channel")
-                    .setSmallIcon(R.drawable.ic_launch)
-                    .setContentTitle(title)
-                    .setContentText(text)
-                    .setStyle(new NotificationCompat.BigTextStyle().bigText(text))
-                    .setPriority(NotificationCompat.PRIORITY_HIGH)
-                    .setAutoCancel(true);
-            nm.notify(2002, b.build());
+
+            // 2. 再走 Toast：若 App 处于前台，弹出友好 Toast 提示用户（不阻断通知栏卡片）
+            if (TaskNotifier.appInForeground) {
+                new Handler(Looper.getMainLooper()).post(() -> {
+                    try {
+                        Toast.makeText(ctx, "✓ " + title + "：" + (text.length() > 30 ? text.substring(0, 30) + "…" : text), Toast.LENGTH_SHORT).show();
+                    } catch (Throwable ignored) {}
+                });
+            }
+
             return "OK";
         } catch (Throwable e) {
             return "ERROR: " + e.getMessage();
@@ -492,22 +609,65 @@ public final class HttpShellService {
         return false;
     }
 
+    private static java.io.File authLeaseFileIfPossible() {
+        Context c = null;
+        try {
+            c = instance().ctx;
+        } catch (Throwable ignored) {
+        }
+        if (c == null) c = tokenCtx;
+        if (c == null) return null;
+        try {
+            HarnessController hc = HarnessController.get(c);
+            if (hc != null && hc.getProot() != null && hc.getProot().getRootfsDir() != null) {
+                return new java.io.File(hc.getProot().getRootfsDir(), "root/.dsh/.auth_lease");
+            }
+        } catch (Throwable ignored) {
+        }
+        return null;
+    }
+
     /** @param action 给用户看的具体动作描述 —— 弹窗必须说清 AI 要干什么，
      *               而不是笼统一句「操作屏幕」，否则用户等于盲签。 */
     private boolean uiAuthorized(String action) {
         String pkg = DshaAccessibilityService.currentPackage();
         boolean sensitive = isSensitiveApp(pkg);
-        if (!sensitive && System.currentTimeMillis() < uiGrantUntil) {
-            return true;
+        long now = System.currentTimeMillis();
+        if (!sensitive) {
+            if (now < uiGrantUntil) {
+                return true;
+            }
+            java.io.File lf = authLeaseFileIfPossible();
+            if (lf != null && lf.isFile()) {
+                try {
+                    String s = new String(java.nio.file.Files.readAllBytes(lf.toPath()),
+                            java.nio.charset.StandardCharsets.UTF_8).trim();
+                    double expSec = Double.parseDouble(s);
+                    if (now / 1000.0 < expSec) {
+                        uiGrantUntil = (long) (expSec * 1000L);
+                        return true;
+                    }
+                } catch (Throwable ignored) {
+                }
+            }
         }
         String where = pkg.isEmpty() ? "当前界面" : pkg;
         String why = sensitive
                 ? "在【" + where + "】里：" + action
                 + "  # 这类应用涉及支付或隐私，每次都需要你确认"
-                : action + "  # 允许后 10 分钟内的屏幕操作不再询问";
+                : action + "  # 允许后 10 分钟内的屏幕与设备操作不再询问";
         boolean ok = requestUserConfirm(why);
         if (ok && !sensitive) {
-            uiGrantUntil = System.currentTimeMillis() + UI_GRANT_MS;
+            long grantExp = now + UI_GRANT_MS;
+            uiGrantUntil = grantExp;
+            java.io.File lf = authLeaseFileIfPossible();
+            if (lf != null) {
+                try {
+                    java.nio.file.Files.write(lf.toPath(),
+                            String.valueOf(grantExp / 1000.0).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                } catch (Throwable ignored) {
+                }
+            }
         }
         return ok;
     }
@@ -581,6 +741,268 @@ public final class HttpShellService {
         } catch (Exception e) {
             return def;
         }
+    }
+
+    /**
+     * {@code /app/overlay?session=&kind=delta|tool|text|done|clear&text=} ——
+     * 把 agent 正在生成的内容送到屏幕顶部的流式悬浮条（{@link OverlayController}）。
+     *
+     * <p>返回值刻意分三种，让插件侧能自己降级：{@code DISABLED}（用户没开这个功能）、
+     * {@code NO_PERMISSION}（没给悬浮窗权限）、{@code OK}。插件拿到前两种就该停止推送 ——
+     * 流式增量是高频调用，白发一路 HTTP 纯属烧电。
+     */
+    /**
+     * {@code /app/plugins}：让 dsh 进程内的插件把<b>真实加载状态</b>报给 App，
+     * 也可以只读回上一次上报。
+     *
+     * <p><b>为什么要走桥，而不是 App 自己读文件</b>：App 只能读 profile 的 package.json
+     * 猜「注册了没有」，而<b>注册了不等于加载成功</b> —— 入口文件缺失、inject 的服务不存在、
+     * patch 里的 name 与目标行对不上，都会让插件静静地不生效，而 package.json 看起来一切正常。
+     * 只有跑在 dsh 进程里的插件能通过 cordis 上下文看到真实状态。这正是「插件装了没反应」
+     * 一直缺的那份证据 —— 缺了它，App 只能猜，用户只能重装。
+     *
+     * <p>约定：
+     * <ul>
+     *   <li>{@code ?loaded=a,b&failed=c}（逗号分隔）→ 上报，存起来给插件页与自检用；</li>
+     *   <li>不带参数 → 只读，返回 {@code LOADED:… / FAILED:… / AT:<毫秒时间戳>}。</li>
+     * </ul>
+     */
+    /**
+     * {@code /app/help}：3090 桥的完整端点清单，纯文本、给 agent 读。
+     *
+     * <p><b>为什么要有这个端点</b>：这份清单原来整份写在 device-shell-guide 的注入提示词里
+     * （12KB，约几千 token），而它是<b>每一轮对话都要付的成本</b> —— 哪怕这轮根本不碰设备。
+     * 挪到运行时按需查之后，提示词只留骨架，agent 要用设备能力时 curl 一次就拿到全部细节。
+     *
+     * <p>还有个额外好处：这份清单跟端点实现<b>在同一个文件里</b>，加端点时顺手就更新了；
+     * 写在插件的提示词里则要改 assets、bump 版本、重签清单，于是必然脱节
+     * （AGENTS.md 里「文档说 14 个端点、实际 26 个」就是这么来的）。
+     */
+    /**
+     * 桥协议版本 —— 插件侧靠它判断「这台 App 支持哪些端点」。
+     *
+     * <p><b>什么时候该涨</b>（写清楚，否则这个号形同虚设）：
+     * <ul>
+     *   <li><b>加新端点：不涨。</b>老插件不知道新端点，行为不变；新插件想用新端点，
+     *       自己 try 一下拿 404 就知道了；</li>
+     *   <li><b>改已有端点的参数含义、返回格式，或删端点：涨。</b>这类改动会让按老约定
+     *       写的插件静默拿到错东西 —— 那正是版本号要挡的事。</li>
+     * </ul>
+     *
+     * <p>所以插件的正确写法是 {@code if (protocol >= N)} 而不是 {@code == N}。
+     */
+    private static final int BRIDGE_PROTOCOL = 1;
+
+    /**
+     * {@code /app/version}：桥协议与 App 版本，给插件做特性检测。
+     *
+     * <p>没有这个端点时，插件只能靠「试着调一下看会不会 404」来猜 App 的能力，
+     * 而 dsh 与 DSHA 是各自升级的 —— 用户完全可能拿新插件配旧 App。
+     */
+    private String appVersion() {
+        return "BRIDGE_PROTOCOL=" + BRIDGE_PROTOCOL + "\n"
+                + "APP_VERSION=" + BuildConfig.VERSION_NAME + "\n"
+                + "APP_CODE=" + BuildConfig.VERSION_CODE + "\n"
+                + "HINT=端点清单见 /app/help；判版本请用 >= 而不是 ==\n";
+    }
+
+    private String appHelp() {
+        return "DSHA 3090 桥端点清单（BRIDGE_PROTOCOL=" + BRIDGE_PROTOCOL + "）\n"
+            + "token 取自 /root/.dsh/.bridge_token，下面记为 $T。\n"
+            + "带中文/空格的参数一律用 -G --data-urlencode，别手写 URL 编码。\n"
+            + "\n"
+            + "== 屏幕操作（无障碍服务，不需要 ADB/Shizuku）==\n"
+            + "读屏  curl -s \"127.0.0.1:3090/app/ui/dump?token=$T\"\n"
+            + "      → 每行「[序号] \"文字\" 可点击 中心=(x,y) 区域=l,t,r,b」\n"
+            + "点按  curl -s -G 127.0.0.1:3090/app/ui/tap --data-urlencode \"text=设置\" --data-urlencode \"token=$T\"\n"
+            + "      → 优先按文字点：控件位置随滚动/动画变，文字不变。没有文字才用 ?x=&y=\n"
+            + "输入  curl -s -G 127.0.0.1:3090/app/ui/input --data-urlencode \"text=内容\" --data-urlencode \"token=$T\"\n"
+            + "      → 填到当前焦点框；没有焦点先 tap 一下输入框\n"
+            + "按键  /app/ui/key?name=back  （back/home/recents/notifications/quicksettings/lock）\n"
+            + "滑动  /app/ui/swipe?x1=500&y1=1500&x2=500&y2=500&ms=300\n"
+            + "截屏  /app/ui/screenshot   → 存 PNG 到 Download/DSHA 并返回路径（不回 base64）\n"
+            + "节奏：每次点按/输入后先 dump 再决定下一步，别凭记忆连点。\n"
+            + "\n"
+            + "== 设备与应用 ==\n"
+            + "/app/device                     机型/系统/电量/网络/屏幕/存储/内存\n"
+            + "/app/apps?q=微信&limit=50       已装应用（默认只列第三方）\n"
+            + "/app/launch?pkg=com.tencent.mm  启动应用\n"
+            + "/app/clip                       读剪贴板（需 App 在前台，系统限制）\n"
+            + "/app/clip + text=…              写剪贴板\n"
+            + "/app/readfile?path=/sdcard/…    读外部文件\n"
+            + "/sdcard 已挂载，Download / DCIM 等公共目录可直接读写\n"
+            + "\n"
+            + "== 与用户交互 ==\n"
+            + "/app/ask?options=继续|取消 + q=…  弹窗阻塞等回答（最多三个选项）\n"
+            + "/app/notify?title=… + text=…      通知栏\n"
+            + "/app/toast + text=…               App 内提示\n"
+            + "/app/vibrate?ms=300               震动（长任务跑完叫醒用户）\n"
+            + "/app/share（text= 或 path=）      分享到其它应用\n"
+            + "/app/open?url=https://…           打开链接\n"
+            + "/app/export?path=/root/report.md  把产物交给用户 → 落 Download/DSHA\n"
+            + "建议：需要用户拍板用 /app/ask 而不是干等；长任务结束用 notify 或 vibrate 叫人；\n"
+            + "产出报告用 /app/export，别只留在容器里。\n"
+            + "\n"
+            + "== 传感器与位置（默认关闭，需用户在配置页勾选）==\n"
+            + "/app/location（加 fresh=1 强制重新定位，可能等数秒）\n"
+            + "/app/sensors 列表 · /app/sensor?name=light 读值\n"
+            + "（light 环境光 lux / accel / gyro / magnet / pressure / proximity /\n"
+            + " gravity / rotation 姿态四元数 / steps 开机后步数）\n"
+            + "/app/torch?on=1 手电\n"
+            + "这三类返回 DISABLED（用户没开该能力）或 NO_PERMISSION（没授系统权限）时，\n"
+            + "照原话告诉用户去哪开，不要重试 —— 重试不会让开关自己变。\n"
+            + "\n"
+            + "== 元信息 ==\n"
+            + "/app/version                          桥协议版本 + App 版本（特性检测用）\n"
+            + "/app/help                             本清单\n"
+            + "\n"
+            + "== 插件状态 ==\n"
+            + "/app/plugins                          读回上次上报的加载状态\n"
+            + "/app/plugins?loaded=a,b&failed=c      上报（插件侧用）\n"
+            + "\n"
+            + "== 设备 shell（ADB 无线调试，用户可能没开）==\n"
+            + "/root/dsh-bin/adb-shell \"命令\"        shell 级（uid=2000）\n"
+            + "包装命令不存在时：python3 /root/.dsh/adb-shell.py \"命令\"\n"
+            + "报连不上/未配对：先看上面的 App 层接口能不能办成；确实必须 shell 才请用户到\n"
+            + "「配置」页开「ADB 设备通道」并配对，别反复试同一条命令。\n"
+            + "不要用 /root/dsh-bin/adb 或裸 adb —— 那是守卫包装脚本，会失败。\n"
+            + "\n"
+            + "== root（--su）==\n"
+            + "默认权限是 shell 级（uid=2000，非 root）。不要主动用 --su；\n"
+            + "只有用户明确要求 root 操作时才尝试，且要先请他到「配置」页勾选「允许 root shell」。\n";
+    }
+
+    private String appPlugins(String path) {
+        try {
+            String q = queryOf(path);
+            String loaded = getParam(q, "loaded", null);
+            String failed = getParam(q, "failed", null);
+            android.content.SharedPreferences sp =
+                    ctx.getSharedPreferences("deepseekharness", Context.MODE_PRIVATE);
+            if (loaded == null && failed == null) {
+                return "LOADED:" + sp.getString("plugin_loaded", "")
+                        + "\nFAILED:" + sp.getString("plugin_failed", "")
+                        + "\nAT:" + sp.getLong("plugin_report_ts", 0L);
+            }
+            sp.edit()
+                    .putString("plugin_loaded", loaded == null ? "" : loaded.trim())
+                    .putString("plugin_failed", failed == null ? "" : failed.trim())
+                    .putLong("plugin_report_ts", System.currentTimeMillis())
+                    .apply();
+            // 有加载失败的就写进活动日志 —— 那是用户唯一能看到「插件为什么没反应」的地方
+            if (failed != null && !failed.trim().isEmpty()) {
+                try {
+                    HarnessController.get(ctx).logActivity("插件加载失败：" + failed.trim());
+                } catch (Throwable ignored) {
+                }
+            }
+            return "OK";
+        } catch (Throwable e) {
+            return "ERROR: " + e;
+        }
+    }
+
+    private String appOverlay(String path) {
+        try {
+            String q = queryOf(path);
+            String kind = getParam(q, "kind", "delta");
+            String text = getParam(q, "text", "");
+            String session = getParam(q, "session", "");
+
+            // 通知栏同步实时运行状态与「🛑 停止任务」紧急制动按钮
+            if ("tool".equals(kind) || "text".equals(kind)) {
+                if (!text.trim().isEmpty()) {
+                    showRunningNotification(text);
+                }
+            } else if ("done".equals(kind) || "clear".equals(kind)) {
+                cancelRunningNotification();
+            }
+
+            if (!OverlayController.enabled(ctx)) return "DISABLED";
+            if (!OverlayController.permitted(ctx)) return "NO_PERMISSION";
+            // 让插件知道用户想不想看这两类内容，省得白发一路 HTTP
+            if ("reasoning".equals(kind) && !OverlayController.showReasoning(ctx)) {
+                return "SKIP_REASONING";
+            }
+            OverlayController.push(ctx, session, kind, text);
+            return OverlayController.showCommand(ctx) ? "OK" : "OK_NO_CMD";
+        } catch (Throwable e) {
+            return "ERROR: " + e.getMessage();
+        }
+    }
+
+    private String appTaskRunning(String path) {
+        try {
+            String q = queryOf(path);
+            String title = getParam(q, "title", "DSHA · 正在执行");
+            String text = getParam(q, "text", "智能体正在执行自动化任务...");
+            showRunningNotification(title, text);
+            return "OK";
+        } catch (Throwable e) {
+            return "ERROR: " + e.getMessage();
+        }
+    }
+
+    private String appTaskCancel() {
+        try {
+            cancelRunningNotification();
+            return "OK";
+        } catch (Throwable e) {
+            return "ERROR: " + e.getMessage();
+        }
+    }
+
+    private void showRunningNotification(String text) {
+        showRunningNotification("DSHA · 正在执行", text);
+    }
+
+    private void showRunningNotification(String title, String text) {
+        try {
+            if (Build.VERSION.SDK_INT >= 26) {
+                NotificationChannel ch = new NotificationChannel(
+                        Constants.CHANNEL_AGENT_RUNNING, "Agent 运行状态",
+                        NotificationManager.IMPORTANCE_HIGH);
+                ch.setDescription("智能体运行中实时操作步骤通知");
+                NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+                if (nm != null) nm.createNotificationChannel(ch);
+            }
+
+            Intent openAppIntent = new Intent(ctx, QuickChatSheetActivity.class)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            PendingIntent contentPi = PendingIntent.getActivity(ctx, 110, openAppIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+            Intent stopIntent = new Intent(ctx, ConfirmReceiver.class)
+                    .setAction(ConfirmReceiver.ACTION_STOP_TASK);
+            PendingIntent stopPi = PendingIntent.getBroadcast(ctx, 111, stopIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+            NotificationCompat.Action stopAction = new NotificationCompat.Action.Builder(
+                    R.drawable.ic_launch, "🛑 停止任务", stopPi)
+                    .build();
+
+            String shortMsg = (text == null || text.trim().isEmpty()) ? "智能体正在执行自动化任务..." : shortText(text);
+
+            NotificationCompat.Builder nb = new NotificationCompat.Builder(ctx, Constants.CHANNEL_AGENT_RUNNING)
+                    .setSmallIcon(R.drawable.ic_launch)
+                    .setContentTitle(title != null && !title.isEmpty() ? title : "DSHA · 正在执行")
+                    .setContentText(shortMsg)
+                    .setStyle(new NotificationCompat.BigTextStyle().bigText(text != null && !text.isEmpty() ? text : shortMsg))
+                    .setContentIntent(contentPi)
+                    .addAction(stopAction)
+                    .setOngoing(true)
+                    .setPriority(NotificationCompat.PRIORITY_HIGH);
+
+            NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (nm != null) nm.notify(Constants.NOTIF_TASK_RUNNING, nb.build());
+        } catch (Throwable ignored) {}
+    }
+
+    private void cancelRunningNotification() {
+        try {
+            NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (nm != null) nm.cancel(Constants.NOTIF_TASK_RUNNING);
+        } catch (Throwable ignored) {}
     }
 
     private String appToast(String path) {
@@ -876,59 +1298,64 @@ public final class HttpShellService {
         }
     }
 
-    /** /app/ask?q=问题&options=选项A|选项B|选项C ：弹窗问用户，阻塞等回答（最多 3 个选项，120 秒超时） */
+    /** /app/ask?q=问题&options=选项A|选项B|选项C ：弹窗 + 通知栏双通道问用户，阻塞等回答（最多 3 个选项，120 秒超时） */
     private String appAsk(String path) {
         String q = getParam(queryOf(path), "q", "");
         String optRaw = getParam(queryOf(path), "options", "");
         if (q.isEmpty()) return "NO_QUESTION";
-        if (askBusy) return "[BUSY] 已有一个提问在等用户回答";
-        final MainActivity act = MainActivity.current;
-        if (act == null) {
-            return "[APP_BACKGROUND] App 不在前台，弹不出提问 —— 可先 /app/notify 提醒用户打开 DSHA";
-        }
         String[] parts = optRaw.isEmpty() ? new String[] { "好" } : optRaw.split("\\|");
         final String[] opts = parts.length <= 3 ? parts : new String[] { parts[0], parts[1], parts[2] };
-        askBusy = true;
+        // 检查与置位必须原子（见 askBusy 声明处）。CAS 成功之后立刻进 try，
+        // 保证任何返回路径都会在 finally 里放开它。
+        if (!askBusy.compareAndSet(false, true)) {
+            return "[BUSY] 已有一个提问在等用户回答";
+        }
         try {
             final CountDownLatch latch = new CountDownLatch(1);
-            askLatch = latch;
+            final long myEpoch = askEpoch.incrementAndGet();
             askAnswer = "";
-            act.runOnUiThread(() -> {
-                try {
-                    androidx.appcompat.app.AlertDialog.Builder b =
-                            new androidx.appcompat.app.AlertDialog.Builder(act)
-                                    .setTitle("助手提问").setMessage(q);
-                    b.setPositiveButton(opts[0], (d, w) -> {
-                        askAnswer = opts[0];
-                        latch.countDown();
-                    });
-                    if (opts.length > 1) {
-                        b.setNegativeButton(opts[1], (d, w) -> {
-                            askAnswer = opts[1];
-                            latch.countDown();
-                        });
+            askResolved.set(false);
+            pendingAskLatch = latch;
+
+            // 1. 发送高优先级常驻通知（带选项快捷操作按钮，前台、后台与锁屏均可一键回答）
+            showAskNotification(q, opts, myEpoch);
+
+            // 2. 若前台 Activity 活跃，同时展示弹窗
+            final MainActivity act = MainActivity.current;
+            if (act != null) {
+                act.runOnUiThread(() -> {
+                    try {
+                        if (act.isFinishing() || act.isDestroyed()) return;
+                        androidx.appcompat.app.AlertDialog.Builder b =
+                                new androidx.appcompat.app.AlertDialog.Builder(act)
+                                        .setTitle("💬 助手提问").setMessage(q);
+                        b.setPositiveButton(opts[0], (d, w) -> resolveAsk(opts[0], myEpoch));
+                        if (opts.length > 1) {
+                            b.setNegativeButton(opts[1], (d, w) -> resolveAsk(opts[1], myEpoch));
+                        }
+                        if (opts.length > 2) {
+                            b.setNeutralButton(opts[2], (d, w) -> resolveAsk(opts[2], myEpoch));
+                        }
+                        b.setCancelable(false);
+                        pendingAskDialog = b.show();
+                    } catch (Throwable e) {
+                        android.util.Log.w("DSHA", "提问弹窗弹出失败，仍可从通知回答：" + e);
                     }
-                    if (opts.length > 2) {
-                        b.setNeutralButton(opts[2], (d, w) -> {
-                            askAnswer = opts[2];
-                            latch.countDown();
-                        });
-                    }
-                    b.setOnCancelListener(d -> latch.countDown());
-                    b.setOnDismissListener(d -> latch.countDown());
-                    b.show();
-                } catch (Throwable e) {
-                    latch.countDown();
-                }
-            });
-            boolean answered = latch.await(120, TimeUnit.SECONDS);
-            if (!answered) return "[TIMEOUT] 用户 120 秒内没有回答";
-            return askAnswer.isEmpty() ? "[DISMISSED] 用户关掉了提问框" : askAnswer;
-        } catch (InterruptedException e) {
-            return "[INTERRUPTED]";
+                });
+            }
+
+            try {
+                boolean answered = latch.await(120, TimeUnit.SECONDS);
+                if (!answered) return "[TIMEOUT] 用户 120 秒内没有回答";
+                return askAnswer.isEmpty() ? "[DISMISSED] 用户关掉了提问框" : askAnswer;
+            } catch (InterruptedException e) {
+                return "[INTERRUPTED]";
+            }
         } finally {
-            askBusy = false;
-            askLatch = null;
+            pendingAskLatch = null;
+            dismissAskDialog();
+            cancelAskNotification();
+            askBusy.set(false);
         }
     }
 
@@ -963,24 +1390,12 @@ public final class HttpShellService {
 
 /** 从（仅含 query 的）查询串提取参数。调用方务必先截取 '?' 之后的内容。 */
     private static String getParam(String q, String key, String def) {
-        try {
-            int i = q.indexOf(key + "=");
-            if (i < 0) return def;
-            String v = q.substring(i + key.length() + 1);
-            int amp = v.indexOf('&');
-            if (amp >= 0) v = v.substring(0, amp);
-            int frag = v.indexOf('#');
-            if (frag >= 0) v = v.substring(0, frag);
-            return URLDecoder.decode(v, "UTF-8");
-        } catch (Exception e) {
-            return def;
-        }
+        return Query.param(q, key, def);
     }
 
     // 便捷包装：路径中取 query 部分
     private static String queryOf(String path) {
-        int i = path.indexOf('?');
-        return i >= 0 ? path.substring(i + 1) : "";
+        return Query.of(path);
     }
 
     private boolean confirmEnabled() {
@@ -1005,10 +1420,17 @@ public final class HttpShellService {
             // epoch 先递增：上一轮残留的弹窗/通知按钮带的是旧 epoch，会被丢弃
             final long myEpoch = confirmEpoch.incrementAndGet();
             pendingAllow = false;   // 先写标志，再发布 latch
+            confirmResolved.set(false);  // 必须早于发布 latch：latch 一露面就可能有点击进来
             pendingLatch = latch;
 
             // 通知是权威渠道（前后台都在），前台再叠一个弹窗当快捷方式
             showConfirmNotification(cmd, myEpoch);
+            // 第三条渠道：悬浮条上就地批准。agent 干活时用户往往并不在 App 里 ——
+            // 拉下通知栏找那条通知、或者切回 App，都比点一下已经浮在最上层的按钮慢。
+            // 三条渠道共用同一个 epoch + latch，谁先点谁生效。
+            OverlayController.askConfirm(ctx, cmd,
+                    () -> resolveConfirm(true, myEpoch),
+                    () -> resolveConfirm(false, myEpoch));
             final MainActivity act = MainActivity.current;
             if (act != null) {
                 final String prompt = "模型试图在设备上执行：\n" + cmd + "\n\n是否允许？";
@@ -1050,6 +1472,7 @@ public final class HttpShellService {
             pendingLatch = null;
             dismissConfirmDialog();
             cancelConfirmNotification();
+            OverlayController.dismissConfirm(ctx);
             confirmBusy.set(false);
         }
     }
@@ -1064,15 +1487,17 @@ public final class HttpShellService {
         }
     }
 
-    /** 通知按钮（ConfirmReceiver）与前台弹窗按钮共用的回调。
-     *  epoch 校验 + latch 认领：丢弃迟到的、属于上一个请求的点击。 */
+    /** 通知按钮（ConfirmReceiver）、前台弹窗按钮与悬浮条按钮共用的回调。
+     *  epoch 校验 + 原子认领：丢弃迟到的（属于上一个请求的）点击，以及同一轮里后到的那次。 */
     public void resolveConfirm(boolean allow, long epoch) {
         if (epoch != confirmEpoch.get()) {
             android.util.Log.i("DSHA", "忽略过期的确认点击（epoch " + epoch + "）");
             return;
         }
         CountDownLatch l = pendingLatch;
-        if (l == null || l.getCount() == 0) return; // 已决或无挂起
+        if (l == null || l.getCount() == 0) return; // 已决或无挂起（快速路径）
+        // 真正的认领在这里，且必须原子 —— 上面那个 getCount 检查挡不住两条渠道同时点。
+        if (!confirmResolved.compareAndSet(false, true)) return;
         pendingAllow = allow;
         l.countDown();
         dismissConfirmDialog();
@@ -1100,6 +1525,12 @@ public final class HttpShellService {
     private void showConfirmNotification(String cmd, long epoch) {
         createConfirmChannel();
         String shortCmd = cmd.length() > 100 ? cmd.substring(0, 100) + "…" : cmd;
+        Intent openAppIntent = new Intent(ctx, MainActivity.class)
+                .putExtra("open_web", true)
+                .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        PendingIntent contentPi = PendingIntent.getActivity(ctx, 30, openAppIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
         // epoch 随 Intent 带回：残留通知上的旧按钮会因 epoch 过期被丢弃
         Intent allowI = new Intent(ctx, ConfirmReceiver.class).setAction(ConfirmReceiver.ACTION_ALLOW)
                 .putExtra(ConfirmReceiver.EXTRA_EPOCH, epoch);
@@ -1115,6 +1546,8 @@ public final class HttpShellService {
                 .setContentText("模型试图执行：" + shortCmd)
                 .setStyle(new NotificationCompat.BigTextStyle()
                         .bigText("模型试图在设备上执行：\n" + cmd + "\n\n是否允许？"))
+                .setContentIntent(contentPi)
+                .setAutoCancel(true)
                 .addAction(0, "允许", allowPi)
                 .addAction(0, "拒绝", denyPi)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
@@ -1127,6 +1560,89 @@ public final class HttpShellService {
     private void cancelConfirmNotification() {
         NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
         if (nm != null) nm.cancel(CONFIRM_NOTIF_ID);
+    }
+
+    private void showAskNotification(String q, String[] opts, long epoch) {
+        createConfirmChannel();
+        String shortQ = q.length() > 100 ? q.substring(0, 100) + "…" : q;
+        Intent openAppIntent = new Intent(ctx, MainActivity.class)
+                .putExtra("open_web", true)
+                .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        PendingIntent contentPi = PendingIntent.getActivity(ctx, 39, openAppIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+        NotificationCompat.Builder nb = new NotificationCompat.Builder(ctx, CONFIRM_CHANNEL)
+                .setSmallIcon(R.drawable.ic_launch)
+                .setContentTitle("💬 助手提问")
+                .setContentText(shortQ)
+                .setStyle(new NotificationCompat.BigTextStyle().bigText(q))
+                .setContentIntent(contentPi)
+                .setAutoCancel(true)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setOngoing(true);
+
+        for (int i = 0; i < opts.length; i++) {
+            String opt = opts[i];
+            Intent intent = new Intent(ctx, ConfirmReceiver.class)
+                    .setAction(ConfirmReceiver.ACTION_ASK_ANSWER)
+                    .putExtra(ConfirmReceiver.EXTRA_EPOCH, epoch)
+                    .putExtra(ConfirmReceiver.EXTRA_ANSWER, opt);
+            PendingIntent pi = PendingIntent.getBroadcast(ctx, 40 + i, intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+            nb.addAction(0, opt, pi);
+        }
+
+        // 挂载 RemoteInput 直接就地文本输入快捷回复
+        androidx.core.app.RemoteInput remoteInput = new androidx.core.app.RemoteInput.Builder(ConfirmReceiver.EXTRA_REPLY_TEXT)
+                .setLabel("输入回复内容...")
+                .build();
+        Intent replyIntent = new Intent(ctx, ConfirmReceiver.class)
+                .setAction(ConfirmReceiver.ACTION_ASK_REPLY)
+                .putExtra(ConfirmReceiver.EXTRA_EPOCH, epoch);
+        PendingIntent replyPi = PendingIntent.getBroadcast(ctx, 49, replyIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0));
+        NotificationCompat.Action replyAction = new NotificationCompat.Action.Builder(
+                R.drawable.ic_launch, "💬 快捷输入", replyPi)
+                .addRemoteInput(remoteInput)
+                .build();
+        nb.addAction(replyAction);
+
+        NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm != null) nm.notify(Constants.NOTIF_ASK_QUESTION, nb.build());
+    }
+
+    private void cancelAskNotification() {
+        try {
+            NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (nm != null) nm.cancel(Constants.NOTIF_ASK_QUESTION);
+        } catch (Throwable ignored) {}
+    }
+
+    private void dismissAskDialog() {
+        final androidx.appcompat.app.AlertDialog d = pendingAskDialog;
+        if (d == null) return;
+        pendingAskDialog = null;
+        try {
+            new Handler(Looper.getMainLooper()).post(() -> {
+                try {
+                    if (d.isShowing()) d.dismiss();
+                } catch (Throwable ignored) {}
+            });
+        } catch (Throwable ignored) {}
+    }
+
+    public void resolveAsk(String answer, long epoch) {
+        if (epoch != askEpoch.get()) {
+            android.util.Log.i("DSHA", "忽略过期的提问点击（epoch " + epoch + "）");
+            return;
+        }
+        CountDownLatch l = pendingAskLatch;
+        if (l == null || l.getCount() == 0) return;
+        if (!askResolved.compareAndSet(false, true)) return;
+        askAnswer = answer;
+        l.countDown();
+        dismissAskDialog();
+        cancelAskNotification();
     }
 
     private void createConfirmChannel() {

--- a/app/src/main/java/com/deepseekharness/app/LaunchFragment.java
+++ b/app/src/main/java/com/deepseekharness/app/LaunchFragment.java
@@ -58,6 +58,8 @@ public class LaunchFragment extends Fragment {
     private boolean enterWhenReady = false;
     private boolean insideWeb = false;
     private String lastLog = "";
+    /** 上一次已经提示过的插件故障结论：日志每 1.5 秒刷一次，别重复往活动日志里写。 */
+    private String lastPluginHint = "";
     /** 日志文件指纹（size+mtime），未变化则跳过重读（每 1.5s 轮询时省一次文件 IO） */
     private long lastLogSize = -1;
     private long lastLogMtime = -1;
@@ -125,9 +127,9 @@ public class LaunchFragment extends Fragment {
         }, "dsha-prewarm").start(), 1500);
 
         startBtn.setOnClickListener(v -> {
-            // 用户主动启动：清除"手动停止"标记（否则 keepAlive/预启动会一直不拉起）
-            requireContext().getSharedPreferences("deepseekharness", android.content.Context.MODE_PRIVATE)
-                    .edit().putBoolean("keepalive_paused", false).apply();
+            // 「手动停止」标记不在这里清 —— HarnessController.startWeb() 开头统一清掉，
+            // 这样通知栏「重启」等别的入口也一样解除，不必每个入口自己记得（漏一个就又
+            // 出现「启动了但保活仍不拉起」这类怪状态）。
             if (webReady) {
                 openWeb();
                 return;
@@ -188,12 +190,44 @@ public class LaunchFragment extends Fragment {
             statusText.setText("环境未就绪。若刚装好 APK，请杀掉进程再打开一次以进入解压页。");
         }
 
+        if (getActivity() != null && getActivity().getIntent() != null) {
+            Intent actIntent = getActivity().getIntent();
+            if (actIntent.getBooleanExtra("open_web", false) || actIntent.getBooleanExtra("auto_enter_web", false)) {
+                enterWhenReady = true;
+            }
+        }
+
         mainHandler.post(tick);
     }
 
-    private void tickOnce() {
+    /** 供通知点击或外部意图唤醒：直接进入 Web 对话界面 */
+    public void enterWebDirectly() {
         if (!isAdded()) return;
-        new Thread(() -> {
+        if (webReady && !insideWeb) {
+            openWeb();
+        } else if (!insideWeb) {
+            enterWhenReady = true;
+            if (!starting && c != null && c.getProot().isOfflineExtracted() && startBtn != null) {
+                startBtn.performClick();
+            }
+        }
+    }
+
+    /**
+     * 心跳间隔：状态还在变的时候要勤，稳定之后没必要。
+     *
+     * <p>原来固定 1.5 秒 —— 也就是说用户停在启动页或 WebUI 里的整段时间，每分钟 40 次
+     * HTTP 探测 + 40 次日志指纹检查。Web 已经起来、人也进去看了的时候，这些只是维持
+     * 状态灯与地址 chip，4 秒一次完全够。而「等启动」那段仍然 1.5 秒：那里的等待秒数要
+     * 走字、就绪后还要自动跳进 WebUI，慢了会被当成卡住。
+     */
+    private long nextTickDelayMs() {
+        if (starting || !webReady) return 1500;   // 还在等启动：保持灵敏
+        return insideWeb ? 4000 : 2500;
+    }
+
+    private void tickOnce() {
+        if (!isAdded()) return;        new Thread(() -> {
             final boolean up = httpOk(uiUrl());
             final String log = readWebLogTail();
             if (!isAdded()) return;
@@ -206,16 +240,34 @@ public class LaunchFragment extends Fragment {
                 webReady = up;
                 applyRunUi(up);
                 refreshHint(); // 每次心跳刷新一次状态行（启动等待期的秒数在这里走字）
+                updateLanAddr(); // 地址 chip 也跟着心跳：局域网后开、WiFi 换网段都能刷新
                 if (up && enterWhenReady && !insideWeb) {
                     enterWhenReady = false;
                     openWeb();
                 }
                 if (!insideWeb && log != null && !log.equals(lastLog)) {
                     lastLog = log;
-                    logText.setText(log.isEmpty() ? "还没有日志。" : log);
+                    // 插件类故障的原始报错基本读不了（一屏栈 + 中间半行插件名），
+                    // 而它恰恰是「Web 打不开」最常见的原因。认出来就把结论摆在日志上方，
+                    // 别让用户对着栈猜、更别让他去清数据重装（有人这么试过，白费）。
+                    String hint = PluginErrorHint.describe(log);
+                    if (!hint.isEmpty()) {
+                        logText.setText(hint + "\n\n———— 原始日志 ————\n" + log);
+                        if (!hint.equals(lastPluginHint)) {
+                            lastPluginHint = hint;
+                            // 记进活动日志：用户过后回想「刚才到底怎么了」还能查到
+                            try {
+                                c.logActivity("Web 启动受阻，疑似插件问题："
+                                        + hint.replace("\n", " "));
+                            } catch (Throwable ignored) {
+                            }
+                        }
+                    } else {
+                        logText.setText(log.isEmpty() ? "还没有日志。" : log);
+                    }
                     logScroll.post(() -> logScroll.fullScroll(View.FOCUS_DOWN));
                 }
-                mainHandler.postDelayed(tick, 1500);
+                mainHandler.postDelayed(tick, nextTickDelayMs());
             });
         }, "dsha-launch-tick").start();
     }
@@ -290,6 +342,7 @@ public class LaunchFragment extends Fragment {
                     gs.open(GeckoRuntime.getDefault(requireContext()));
                     gv.setSession(gs);
                 }
+                attachGeckoDownload(gs);
                 gs.loadUri(uiUrl());
                 return; // GeckoView 加载，不走 WebView
             } catch (Throwable e) {
@@ -322,6 +375,22 @@ public class LaunchFragment extends Fragment {
                         + "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36");
             }
             webView.setWebViewClient(new WebViewClient());
+            // 系统 WebView 的下载：DownloadListener 只给 URL，得自己再发一次请求。
+            // 产物与 GeckoView 那条路落同一个目录（Download/DSHA/下载/）。
+            webView.setDownloadListener((url, ua, cd, mime, len) -> {
+                final android.content.Context appCtx = requireContext().getApplicationContext();
+                android.widget.Toast.makeText(appCtx, "开始下载…",
+                        android.widget.Toast.LENGTH_SHORT).show();
+                new Thread(() -> {
+                    String name = DownloadSink.guessName(url, cd, "download");
+                    String path = DownloadSink.download(appCtx, url, name, mime);
+                    final String msg = path == null
+                            ? "下载失败：" + name : "已保存到 " + path;
+                    new android.os.Handler(android.os.Looper.getMainLooper()).post(() ->
+                            android.widget.Toast.makeText(appCtx, msg,
+                                    android.widget.Toast.LENGTH_LONG).show());
+                }).start();
+            });
             webView.setWebChromeClient(new WebChromeClient() {
                 @Override
                 public boolean onShowFileChooser(WebView view, ValueCallback<Uri[]> cb,
@@ -340,7 +409,7 @@ public class LaunchFragment extends Fragment {
         webView.loadUrl(uiUrl());
     }
 
-    private void closeWeb() {
+    public void closeWeb() {
         if (!insideWeb) return;
         insideWeb = false;
         webPane.setVisibility(View.GONE);
@@ -383,6 +452,53 @@ public class LaunchFragment extends Fragment {
         return base;
     }
 
+    /**
+     * 给 GeckoSession 接上下载。
+     *
+     * <p>GeckoView 对「不能内联显示的响应」默认直接丢弃 —— 从来没设过 ContentDelegate
+     * 的后果就是：WebUI 里点导出/下载什么反应都没有，既不报错也不落文件。产物统一放
+     * {@code Download/DSHA/下载/}。
+     *
+     * <p>响应体必须在后台线程读（主线程读会卡住 UI，大文件直接 ANR）。
+     */
+    private void attachGeckoDownload(GeckoSession gs) {
+        final android.content.Context appCtx = requireContext().getApplicationContext();
+        gs.setContentDelegate(new GeckoSession.ContentDelegate() {
+            @Override
+            public void onExternalResponse(@NonNull GeckoSession session,
+                                           @NonNull org.mozilla.geckoview.WebResponse response) {
+                new Thread(() -> {
+                    String cd = headerOf(response.headers, "Content-Disposition");
+                    String mime = headerOf(response.headers, "Content-Type");
+                    String name = DownloadSink.guessName(response.uri, cd, "download");
+                    String path = null;
+                    try {
+                        if (response.body != null) {
+                            path = DownloadSink.save(appCtx, response.body, name, mime);
+                        }
+                    } catch (Throwable t) {
+                        android.util.Log.w("DSHA", "GeckoView 下载失败: " + t);
+                    }
+                    final String msg = path == null ? "下载失败：" + name : "已保存到 " + path;
+                    new android.os.Handler(android.os.Looper.getMainLooper()).post(() ->
+                            android.widget.Toast.makeText(appCtx, msg,
+                                    android.widget.Toast.LENGTH_LONG).show());
+                }).start();
+            }
+        });
+    }
+
+    /** HTTP 头名大小写不敏感取值（GeckoView 给的 map 不保证大小写）。 */
+    private static String headerOf(java.util.Map<String, String> headers, String key) {
+        if (headers == null || key == null) return null;
+        String v = headers.get(key);
+        if (v != null) return v;
+        for (java.util.Map.Entry<String, String> e : headers.entrySet()) {
+            if (e.getKey() != null && e.getKey().equalsIgnoreCase(key)) return e.getValue();
+        }
+        return null;
+    }
+
     private String uiUrl() {
         String base = "http://127.0.0.1:" + c.getPort() + "/";
         // dsh 的 Web 服务加了 token 鉴权（本机任何 App 都能访问 127.0.0.1，
@@ -392,32 +508,77 @@ public class LaunchFragment extends Fragment {
         return t.isEmpty() ? base : base + "?dsha_t=" + android.net.Uri.encode(t);
     }
 
+    /** 启动页那行可点的地址 chip。
+     *
+     *  <p>用户反馈「启动页给的 URL 用不了，AI 找出来 :3080/?dsha_t=... 才是对的」。
+     *  原因是这里<b>只显示局域网地址</b>（3081），而那条链当时是坏的 ——
+     *  {@code stripTokenFromRequestLine} 把请求行的 HTTP 版本吃掉，后端直接 400。
+     *  用手机自带浏览器打开所需要的本机地址（带 dsh 自己的 {@code dsha_t}）
+     *  从来没有在界面上出现过，用户只能让 agent 去日志里挖。
+     *
+     *  <p>现在一行 chip 收两个入口，点开再选本机 / 同 WiFi。另外它以前只在
+     *  onViewCreated 算一次 —— 局域网后来才开、或者 WiFi 换了网段都不会刷新，
+     *  现在跟着心跳走。 */
     private void updateLanAddr() {
+        if (!webReady) {
+            lanAddrText.setVisibility(View.GONE);
+            return;
+        }
+        lanAddrText.setText("在浏览器中打开 ▸ 点这里取地址（本机 / 同 WiFi）");
+        lanAddrText.setVisibility(View.VISIBLE);
+        lanAddrText.setOnClickListener(v -> showBrowserAddrDialog());
+    }
+
+    /** 列出可用的浏览器访问地址。地址里的 token 就是凭据，所以复制后要提醒一句。 */
+    private void showBrowserAddrDialog() {
+        final String local = uiUrl();
         boolean lan = requireContext()
                 .getSharedPreferences("deepseekharness", android.content.Context.MODE_PRIVATE)
                 .getBoolean("lan_mode", false);
-        if (!lan) {
-            lanAddrText.setVisibility(View.GONE);
-            return;
-        }
         String ip = HarnessController.getLanAddress();
-        if (ip == null) {
-            lanAddrText.setVisibility(View.GONE);
-            return;
+        final String lanAddr = (lan && ip != null && !ip.isEmpty())
+                ? "http://" + ip + ":" + LanProxyService.LAN_PORT + "/?token="
+                        + LanProxyService.getLanToken(requireContext())
+                : null;
+
+        final java.util.List<String> items = new java.util.ArrayList<>();
+        final java.util.List<Runnable> acts = new java.util.ArrayList<>();
+
+        items.add("用本机浏览器打开\n" + local);
+        acts.add(() -> AboutDialog.openBrowser(requireContext(), local));
+        items.add("复制本机地址");
+        acts.add(() -> copyAddr("本机地址", local));
+        if (lanAddr != null) {
+            items.add("复制局域网地址（同 WiFi 的其它设备用）\n" + lanAddr);
+            acts.add(() -> copyAddr("局域网地址", lanAddr));
+        } else if (lan) {
+            items.add("局域网已开启，但还没拿到 WiFi 地址（连上 WiFi 再看）");
+            acts.add(() -> { });
+        } else {
+            items.add("局域网访问未开启 —— 去「配置」页打开后再来取地址");
+            acts.add(() -> { });
         }
-        // 注意：局域网访问走 App 侧 LanProxyService 桥（端口 3081 → 后端 3080），
-        // 不是直连 3080（直连需要 lan-bind 补丁成功且 CLI 放行 0.0.0.0，不可靠）
-        // LAN 访问带 token（鉴权：防同 WiFi 任意设备访问 dsh）
-        final String lanTok = LanProxyService.getLanToken(requireContext());
-        final String copyAddr = "http://" + ip + ":" + LanProxyService.LAN_PORT + "/?token=" + lanTok;
-        lanAddrText.setText("局域网访问: " + copyAddr + "  （同 WiFi 设备可打开）");
-        lanAddrText.setVisibility(View.VISIBLE);
-        lanAddrText.setOnClickListener(v -> {
+
+        new androidx.appcompat.app.AlertDialog.Builder(requireContext())
+                .setTitle("在浏览器中打开")
+                .setItems(items.toArray(new String[0]), (d, which) -> {
+                    if (which >= 0 && which < acts.size()) acts.get(which).run();
+                })
+                .setNegativeButton("关闭", null)
+                .show();
+    }
+
+    private void copyAddr(String label, String addr) {
+        try {
             android.content.ClipboardManager cm = (android.content.ClipboardManager)
                     requireContext().getSystemService(android.content.Context.CLIPBOARD_SERVICE);
-            cm.setPrimaryClip(android.content.ClipData.newPlainText("lan", copyAddr));
-            Toast.makeText(requireContext(), "局域网地址已复制", Toast.LENGTH_SHORT).show();
-        });
+            if (cm != null) cm.setPrimaryClip(android.content.ClipData.newPlainText(label, addr));
+            // token 就写在地址里，等于密码 —— 说清楚，别让人随手发到群里
+            Toast.makeText(requireContext(), label + "已复制（里面的 token 相当于密码，别外发）",
+                    Toast.LENGTH_LONG).show();
+        } catch (Throwable e) {
+            Toast.makeText(requireContext(), "复制失败：" + addr, Toast.LENGTH_LONG).show();
+        }
     }
 
     private boolean goExtractIfNeeded() {

--- a/app/src/main/java/com/deepseekharness/app/MainActivity.java
+++ b/app/src/main/java/com/deepseekharness/app/MainActivity.java
@@ -28,12 +28,39 @@ public class MainActivity extends AppCompatActivity {
     /** 当前前台 Activity（HttpShellService 用它弹确认框）；null = 不在前台 */
     public static volatile MainActivity current = null;
 
+    /** 自动恢复弹窗的「手动选择」出口。分区存储下 SAF 是读取「别的安装写进
+     *  Download/DSHA 的备份」唯一不需要权限、也一定能成的办法（issue #22）。
+     *  注册必须发生在 Activity 进入 STARTED 之前，所以放在字段初始化里。 */
+    private final androidx.activity.result.ActivityResultLauncher<String[]> backupPicker =
+            registerForActivityResult(
+                    new androidx.activity.result.contract.ActivityResultContracts.OpenDocument(),
+                    uri -> {
+                        if (uri != null) {
+                            HarnessController.get(this).restorePickedUri(this, uri);
+                        }
+                    });
+
+    /** 供 HarnessController 的恢复弹窗调用：打开系统文件选择器挑备份包。 */
+    public void pickBackupForRestore() {
+        try {
+            // MediaStore 给 tar.gz 记的 MIME 各家 ROM 不一，多给几个并兜 */*，
+            // 否则用户会看到「没有可选文件」。
+            backupPicker.launch(new String[]{"application/gzip", "application/x-gzip",
+                    "application/x-tar", "application/octet-stream", "*/*"});
+        } catch (Throwable e) {
+            Toast.makeText(this, "无法打开文件选择器：" + e, Toast.LENGTH_LONG).show();
+        }
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         // 崩溃捕获已统一在 DshaApp 安装一次（防止 Activity 重建导致重复/覆盖 handler）
 
         // 首次启动进入引导页
+        // 静态标志跨 Activity 存活：若上个 Activity 在恢复弹窗显示期间被销毁，
+        // dismiss 回调不会触发，标志会永久卡在 true，权限弹窗从此再也不弹。
+        HarnessController.restoreFlowActive = false;
         SharedPreferences prefs = getSharedPreferences("deepseekharness", MODE_PRIVATE);
         if (!prefs.getBoolean("welcomed", false)) {
             startActivity(new Intent(this, WelcomeActivity.class));
@@ -75,11 +102,14 @@ public class MainActivity extends AppCompatActivity {
         HarnessController.get(this).ensureBuiltinPluginsReady();
         // 崩溃自愈提示：上次异常退出时读 crash.log 告知原因（不阻塞使用）
         showCrashRecoveryNotice();
-        // 解压完成后进入主界面（skip_extract=true）才检测"全新环境可恢复"，
-        // 避免首启解压前 rootfs 未就绪误弹恢复框（恢复内容会被解压流程覆盖）
-        if (getIntent().getBooleanExtra("skip_extract", false)) {
-            HarnessController.get(this).maybePromptRestore(this);
-        }
+        // 全新环境可恢复检测。走到这里 rootfs 一定已解压（skip_extract=true 来自
+        // ExtractActivity，否则上面 isOfflineExtracted() 不通过就已跳走），所以不再限定
+        // skip_extract —— 首启那次弹窗被用户划掉/进程被杀后，下次开 App 还有机会补上
+        // （issue #22）。方法内部只在 .dsh 尚无用户数据时才弹，不会覆盖已有数据。
+        HarnessController.get(this).maybePromptRestore(this);
+        // 上次重解压没走完 → 数据保护目录还在，问用户要不要把数据恢复回来。
+        // **必须排在升级提示之前**：数据没归位就再提示重解压，只会把同一个失败重复一遍。
+        HarnessController.get(this).maybeOfferPreservedDataRecovery(this);
         // 离线包升级感知：APK 内置新离线包 → 提示重解压（数据自动保留）。
         // 放外面：正常启动（rootfs 已解压）也要检测，方法内部自带
         // isOfflineExtracted() 保护（首启未解压时静默）。
@@ -100,6 +130,16 @@ public class MainActivity extends AppCompatActivity {
 
         nav.setOnItemSelectedListener(item -> {
             int id = item.getItemId();
+            // GitHub 链接输入框只在插件页有意义：切走就藏起来并清空，
+            // 否则它会顶着别的页面的标题栏，还留着上次的内容。
+            android.widget.EditText ghIn = findViewById(R.id.appbar_github_input);
+            View spacer = findViewById(R.id.appbar_spacer);
+            if (ghIn != null) {
+                boolean onPlugins = id == R.id.nav_plugins;
+                ghIn.setVisibility(onPlugins ? View.VISIBLE : View.GONE);
+                if (spacer != null) spacer.setVisibility(onPlugins ? View.GONE : View.VISIBLE);
+                if (!onPlugins) ghIn.setText("");
+            }
             getSupportFragmentManager().popBackStack(null,
                     androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE);
             Fragment f;
@@ -107,7 +147,11 @@ public class MainActivity extends AppCompatActivity {
                 f = new LaunchFragment();
                 setAppTitle("启动");
             } else if (id == R.id.nav_terminal) {
-                f = new TerminalFragment();
+                // 两套终端并存：默认 PTY 那套（跑得了 vim / htop / tmux），页内点「简易」
+                // 可以退回旧的 TextView 版本 —— 新终端万一在某些机型上出问题，
+                // 用户不至于连命令行都没了。选择记在 PtyTerminalFragment.KEY_PTY。
+                f = PtyTerminalFragment.preferred(this)
+                        ? new PtyTerminalFragment() : new TerminalFragment();
                 setAppTitle("终端");
             } else if (id == R.id.nav_plugins) {
                 f = new PluginFragment();
@@ -121,6 +165,47 @@ public class MainActivity extends AppCompatActivity {
         });
         if (savedInstanceState == null) {
             nav.setSelectedItemId(R.id.nav_launch);
+        }
+        handleIntentRouting(getIntent());
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleIntentRouting(intent);
+    }
+
+    private void handleIntentRouting(Intent intent) {
+        if (intent == null) return;
+
+        // 1. 固定重置回到容器后台主页（关闭全屏网页并切到启动页）
+        if (intent.getBooleanExtra("go_home", false)) {
+            BottomNavigationView nav = findViewById(R.id.bottom_nav);
+            if (nav != null && nav.getSelectedItemId() != R.id.nav_launch) {
+                nav.setSelectedItemId(R.id.nav_launch);
+            }
+            Fragment f = getSupportFragmentManager().findFragmentById(R.id.fragment_container);
+            if (f instanceof LaunchFragment) {
+                ((LaunchFragment) f).closeWeb();
+            }
+            return;
+        }
+
+        // 2. 直达全屏网页对话
+        handleNotificationEnterWeb(intent);
+    }
+
+    private void handleNotificationEnterWeb(Intent intent) {
+        if (intent != null && (intent.getBooleanExtra("open_web", false) || intent.getBooleanExtra("auto_enter_web", false))) {
+            BottomNavigationView nav = findViewById(R.id.bottom_nav);
+            if (nav != null && nav.getSelectedItemId() != R.id.nav_launch) {
+                nav.setSelectedItemId(R.id.nav_launch);
+            }
+            Fragment f = getSupportFragmentManager().findFragmentById(R.id.fragment_container);
+            if (f instanceof LaunchFragment) {
+                ((LaunchFragment) f).enterWebDirectly();
+            }
         }
     }
 
@@ -229,6 +314,88 @@ public class MainActivity extends AppCompatActivity {
         }
         current = this;
         TaskNotifier.appInForeground = true;
+        // 从「所有文件访问」设置页返回时能立刻发现已授予 → 补跑一次数据迁移
+        maybeRequestAllFilesAccess();
+    }
+
+    /** 申请「所有文件访问」（All Files Access）。
+     *
+     *  为什么需要：会话/设置/附件要迁到 /sdcard/Documents/dshdata 才能做到
+     *  **卸载重装不丢**。而 Android 11+ 下没有这个权限就写不进公开目录，
+     *  迁移脚本只会静默跳过 —— 用户以为数据安全了，其实还在私有目录里，
+     *  一卸载全没。
+     *
+     *  这是特殊权限，不能用运行时弹窗授予，必须跳系统设置页由用户手动开。
+     *  所以：说清理由 → 跳设置页 → 回来后自动补跑迁移。
+     *  用户拒绝也不纠缠（只问一次），但自检里会持续提示风险。 */
+    /** 供恢复流程结束后调用：那时才轮到我们问权限。 */
+    void recheckAllFilesAccess() {
+        maybeRequestAllFilesAccess();
+    }
+
+    private void maybeRequestAllFilesAccess() {
+        try {
+            if (Build.VERSION.SDK_INT < 30) return;      // 老系统本来就能直写公共目录
+            // 恢复弹窗优先：它和我们要的是同一个权限，用户刚重装时恢复数据更紧急。
+            // 直接 return 而不标记 asked_all_files —— 否则「只问一次」的额度
+            // 会被这次让路白白用掉，等恢复流程结束就再也不问了。
+            if (HarnessController.restoreFlowActive) return;
+            SharedPreferences prefs = getSharedPreferences("deepseekharness", MODE_PRIVATE);
+            if (android.os.Environment.isExternalStorageManager()) {
+                // 已授予：如果之前因为没权限跳过过迁移，这里补跑一次（幂等、失败无感）
+                if (!prefs.getBoolean("public_data_migrated", false)) {
+                    prefs.edit().putBoolean("public_data_migrated", true).apply();
+                    final HarnessController hc = HarnessController.get(this);
+                    new Thread(() -> {
+                        try {
+                            hc.migratePublicDataNow();
+                        } catch (Throwable ignored) {
+                        }
+                    }, "dsha-migrate-after-grant").start();
+                    // 授权后备份就能被枚举到了（#32 实测：授权前 0 个、授权后 14 个全可读）。
+                    // 之前因为看不见而给出的「手动选择」提示，现在可以换成真正的恢复建议。
+                    try {
+                        prefs.edit().remove("restore_prompt_declined").apply();
+                        hc.maybePromptRestore(this);
+                    } catch (Throwable ignored) {
+                    }
+                }
+                return;
+            }
+            // 未授予且已经问过 → 不再打扰（自检里仍会报「卸载会丢数据」）
+            if (prefs.getBoolean("asked_all_files", false)) return;
+            // 正在结束的 Activity 上 show() 会抛 BadTokenException（本项目踩过一次）
+            if (isFinishing() || isDestroyed()) return;
+            prefs.edit().putBoolean("asked_all_files", true).apply();
+            new androidx.appcompat.app.AlertDialog.Builder(this)
+                    .setTitle("让对话数据卸载重装不丢")
+                    .setMessage("需要「所有文件访问」权限，把会话、设置、附件存到\n"
+                            + "内部存储/Documents/dshdata\n\n"
+                            + "· 卸载 App 或换机重装后数据仍在\n"
+                            + "· 文件管理器里可以直接看到和备份\n"
+                            + "· API Key 不会存进去（仍留在 App 私有区并加密）\n\n"
+                            + "不开也能正常使用，但数据只存在 App 私有目录里，卸载即丢失。")
+                    .setPositiveButton("去开启", (d, w) -> {
+                        try {
+                            Intent i = new Intent(
+                                    Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
+                            i.setData(Uri.parse("package:" + getPackageName()));
+                            startActivity(i);
+                        } catch (Throwable e) {
+                            // 个别 ROM 没有这个页面：退到应用详情页，用户仍能找到开关
+                            try {
+                                Intent i2 = new Intent(
+                                        Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                                i2.setData(Uri.parse("package:" + getPackageName()));
+                                startActivity(i2);
+                            } catch (Throwable ignored) {
+                            }
+                        }
+                    })
+                    .setNegativeButton("以后再说", null)
+                    .show();
+        } catch (Throwable ignored) {
+        }
     }
 
     @Override
@@ -245,6 +412,7 @@ public class MainActivity extends AppCompatActivity {
         // 旋转屏幕/配置变化触发 onDestroy 时 isFinishing()=false，保留会话（否则转屏即丢终端）
         if (isFinishing()) {
             TerminalFragment.shutdownShell();
+            PtyTerminalFragment.shutdown();
         }
     }
 

--- a/app/src/main/java/com/deepseekharness/app/QuickChatSheetActivity.java
+++ b/app/src/main/java/com/deepseekharness/app/QuickChatSheetActivity.java
@@ -1,0 +1,796 @@
+package com.deepseekharness.app;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.ValueAnimator;
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.res.ColorStateList;
+import android.content.res.Configuration;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.RippleDrawable;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.DisplayMetrics;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.view.Window;
+import android.view.WindowInsets;
+import android.view.WindowManager;
+import android.view.animation.DecelerateInterpolator;
+import android.view.inputmethod.InputMethodManager;
+import android.webkit.WebChromeClient;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+/**
+ * 快捷对话底部抽屉弹层（纯代码动态构建，零外部 XML 依赖）：
+ * 1. 左右 100% 铺满物理屏幕（Theme.DeepseekHarness.SheetTransparent + Decor 零边距）；
+ * 2. 顶栏 4 按钮像素级规格统一（36x36dp 触摸区、1.85dp 中等线宽、圆角对齐、绝对对称居中）；
+ *    - ① [ ✕ ] 关闭弹层
+ *    - ② [ >_ ] 容器终端控制台
+ *    - ③ [ 💬➕ ] 开启新对话（毫秒级 DOM 触发 / 路由重置）
+ *    - ④ [ ⬒ ] 顺时针旋转 90° 的全屏展开聊天按钮
+ * 3. 多档 15% 阶梯智能吸附停靠（35%/50%/65%/80%/95%），低于 25% 安全退出；
+ * 4. 底部严格锁定在屏幕最底端，拖拽仅顶部上下伸缩；
+ * 5. 全局静态 WebView 单例保活，再次弹出零转圈、零重新加载；
+ * 6. 1:1 精准字体还原（移除 OverviewMode，设置 textZoom 100）；
+ * 7. 注入透明全局 CSS 变量与 DOM 背景，100% 透出毛玻璃半透明卡片与桌面壁纸；
+ * 8. 键盘弹出时：单次状态跃迁平滑拉升至默认高度，卡片顶部与底板绝对锁死在原位，底部全量铺满浅色底板，内部 WebView 视口等额收缩，输入框精准停靠在键盘正上方；
+ * 9. 低位退出在动画完全结束后（onAnimationEnd）重置高度，彻底消除退出时的拉长闪屏。
+ */
+@SuppressLint({"SetJavaScriptEnabled", "ClickableViewAccessibility"})
+public class QuickChatSheetActivity extends Activity {
+
+    public static final int ICON_CLOSE = 1;
+    public static final int ICON_SETTINGS = 2;
+    public static final int ICON_NEW_CHAT = 3;
+    public static final int ICON_FULLSCREEN = 4;
+
+    // 全局静态保活单例，彻底解决再次进入重新转圈加载问题
+    @SuppressLint("StaticFieldLeak")
+    private static WebView sCachedWebView = null;
+    private static boolean sWebLoaded = false;
+
+    private FrameLayout rootOverlay;
+    private LinearLayout sheetCard;
+    private FrameLayout webContainer;
+    private View keyboardSpacer;
+    private ProgressBar progressBar;
+    private TextView errorHint;
+    private HarnessController controller;
+
+    private int screenHeight = 0;
+    private int defaultHeight = 0;
+    private int maxHeight = 0;
+    private int minHeight = 0;
+    private int currentHeight = 0;
+    private boolean isDismissing = false;
+    private boolean isDarkMode = false;
+
+    private float initialTouchY = 0f;
+    private int initialHeightOnTouch = 0;
+
+    // 键盘监听状态跃迁锁与动画控制器（彻底杜绝动画死锁）
+    private boolean isKeyboardElevated = false;
+    private ValueAnimator heightAnimator = null;
+    private ViewTreeObserver.OnGlobalLayoutListener keyboardLayoutListener;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // 窗口基础配置：全屏铺满、底部对齐（彻底锁死底部）、半透明遮罩、点击外部退出
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+        setFinishOnTouchOutside(true);
+
+        Window window = getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+            window.setDimAmount(0.42f);
+            window.setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT);
+            window.setGravity(Gravity.BOTTOM);
+            // 采用 ADJUST_NOTHING：避免 Window 整体与卡片顶边被系统向上顶飞
+            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING);
+            if (window.getDecorView() != null) {
+                window.getDecorView().setPadding(0, 0, 0, 0);
+            }
+        }
+
+        controller = HarnessController.get(this);
+        isDarkMode = (getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)
+                == Configuration.UI_MODE_NIGHT_YES;
+
+        calculateDimensions();
+        setContentView(buildUi());
+        setupGesture();
+        setupKeyboardObserver();
+        attachChatWeb();
+        animateIn();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        animateIn();
+    }
+
+    private void calculateDimensions() {
+        DisplayMetrics dm = getResources().getDisplayMetrics();
+        screenHeight = dm.heightPixels;
+        // 初始高度设为 78%，全屏态 95%，最低安全退出阈值 25%
+        defaultHeight = (int) (screenHeight * 0.78f);
+        maxHeight = (int) (screenHeight * 0.95f);
+        minHeight = (int) (screenHeight * 0.25f);
+        currentHeight = defaultHeight;
+    }
+
+    private View buildUi() {
+        // 毛玻璃半透明底色（浅色：#EBF5F8FC 半透轻白蓝；深色：#EB161B24 半透深灰）
+        int cardBgColor = isDarkMode ? Color.parseColor("#EB161B24") : Color.parseColor("#EBF5F8FC");
+        int textColor = isDarkMode ? Color.parseColor("#E8ECF4") : Color.parseColor("#1A2230");
+        int lineColor = isDarkMode ? Color.parseColor("#302A3344") : Color.parseColor("#30E2E6EE");
+        int handleColor = isDarkMode ? Color.parseColor("#704A5568") : Color.parseColor("#90CBD5E1");
+        int borderColor = isDarkMode ? Color.parseColor("#352A3344") : Color.parseColor("#35CBD5E1");
+
+        // 1. 根全屏透明遮罩容器（左右 100% 撑满）
+        rootOverlay = new FrameLayout(this);
+        rootOverlay.setLayoutParams(new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        rootOverlay.setBackgroundColor(Color.TRANSPARENT);
+        rootOverlay.setPadding(0, 0, 0, 0);
+
+        // 点击外部空白区域退出
+        rootOverlay.setOnTouchListener((v, event) -> {
+            if (event.getAction() == MotionEvent.ACTION_DOWN) {
+                int[] loc = new int[2];
+                sheetCard.getLocationOnScreen(loc);
+                float y = event.getRawY();
+                if (y < loc[1]) {
+                    dismissSheet();
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        // 2. 底部卡片主体（Gravity.BOTTOM 彻底锁定底部，左右 100% 铺满）
+        sheetCard = new LinearLayout(this);
+        FrameLayout.LayoutParams cardLp = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, defaultHeight);
+        cardLp.gravity = Gravity.BOTTOM;
+        cardLp.setMargins(0, 0, 0, 0);
+        sheetCard.setLayoutParams(cardLp);
+        sheetCard.setOrientation(LinearLayout.VERTICAL);
+        sheetCard.setElevation(dpToPx(16));
+        sheetCard.setClipChildren(true);
+
+        // 24dp 顶部圆角毛玻璃半透背景 + 细微描边（一直覆盖到底部，键盘下方完全拥有同色垫板）
+        GradientDrawable cardBg = new GradientDrawable();
+        cardBg.setShape(GradientDrawable.RECTANGLE);
+        float r = dpToPx(24);
+        cardBg.setCornerRadii(new float[]{r, r, r, r, 0, 0, 0, 0});
+        cardBg.setColor(cardBgColor);
+        cardBg.setStroke(dpToPx(1), borderColor);
+        sheetCard.setBackground(cardBg);
+
+        // 3. 紧凑拖拽横条区域（Drag Handle）：压缩留白
+        FrameLayout dragArea = new FrameLayout(this);
+        dragArea.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, dpToPx(14)));
+        dragArea.setPadding(0, dpToPx(5), 0, dpToPx(2));
+
+        View handle = new View(this);
+        FrameLayout.LayoutParams handleLp = new FrameLayout.LayoutParams(dpToPx(36), dpToPx(4));
+        handleLp.gravity = Gravity.CENTER_HORIZONTAL;
+        handle.setLayoutParams(handleLp);
+
+        GradientDrawable handleBg = new GradientDrawable();
+        handleBg.setShape(GradientDrawable.RECTANGLE);
+        handleBg.setCornerRadius(dpToPx(2));
+        handleBg.setColor(handleColor);
+        handle.setBackground(handleBg);
+        dragArea.addView(handle);
+        sheetCard.addView(dragArea);
+
+        // 4. 顶部操作栏（RelativeLayout 保证标题绝对对称居中）
+        RelativeLayout headerBar = new RelativeLayout(this);
+        headerBar.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, dpToPx(42)));
+        headerBar.setPadding(dpToPx(10), 0, dpToPx(10), dpToPx(2));
+
+        // 左侧按钮组：[① ✕ 关闭] + [② >_ 容器设置]
+        LinearLayout leftGroup = new LinearLayout(this);
+        RelativeLayout.LayoutParams leftLp = new RelativeLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.MATCH_PARENT);
+        leftLp.addRule(RelativeLayout.ALIGN_PARENT_START);
+        leftLp.addRule(RelativeLayout.CENTER_VERTICAL);
+        leftGroup.setLayoutParams(leftLp);
+        leftGroup.setOrientation(LinearLayout.HORIZONTAL);
+        leftGroup.setGravity(Gravity.CENTER_VERTICAL);
+
+        // [① ✕ 关闭按钮]
+        View btnClose = createHeaderIconButton(ICON_CLOSE, textColor, "关闭弹层");
+        btnClose.setOnClickListener(v -> dismissSheet());
+        leftGroup.addView(btnClose);
+
+        // [② >_ 容器设置按钮]
+        View btnSettings = createHeaderIconButton(ICON_SETTINGS, textColor, "进入容器主页面");
+        LinearLayout.LayoutParams settingsLp = (LinearLayout.LayoutParams) btnSettings.getLayoutParams();
+        settingsLp.setMarginStart(dpToPx(4));
+        btnSettings.setLayoutParams(settingsLp);
+        btnSettings.setOnClickListener(v -> {
+            Intent intent = new Intent(this, MainActivity.class);
+            intent.putExtra("go_home", true);
+            intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            startActivity(intent);
+            dismissSheet();
+        });
+        leftGroup.addView(btnSettings);
+        headerBar.addView(leftGroup);
+
+        // 中间标题（物理绝对对称居中）
+        TextView title = new TextView(this);
+        RelativeLayout.LayoutParams titleLp = new RelativeLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        titleLp.addRule(RelativeLayout.CENTER_IN_PARENT);
+        title.setLayoutParams(titleLp);
+        title.setText("DSHA 对话");
+        title.setTextColor(textColor);
+        title.setTextSize(16);
+        title.setTypeface(Typeface.DEFAULT_BOLD);
+        headerBar.addView(title);
+
+        // 右侧按钮组：[③ 💬➕ 新建对话] + [④ ⬒ 全屏进入App]
+        LinearLayout rightGroup = new LinearLayout(this);
+        RelativeLayout.LayoutParams rightLp = new RelativeLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.MATCH_PARENT);
+        rightLp.addRule(RelativeLayout.ALIGN_PARENT_END);
+        rightLp.addRule(RelativeLayout.CENTER_VERTICAL);
+        rightGroup.setLayoutParams(rightLp);
+        rightGroup.setOrientation(LinearLayout.HORIZONTAL);
+        rightGroup.setGravity(Gravity.CENTER_VERTICAL);
+
+        // [③ 💬➕ 新建对话按钮]
+        View btnNewChat = createHeaderIconButton(ICON_NEW_CHAT, textColor, "开启新对话");
+        btnNewChat.setOnClickListener(v -> {
+            if (sCachedWebView != null) {
+                String js = "(function() {" +
+                        "  var btn = document.querySelector('[class*=\"newSession\"], [aria-label*=\"新会话\"], [aria-label*=\"新建\"], button[title*=\"新会话\"], button[title*=\"New session\"], button[title*=\"New Chat\"]');" +
+                        "  if (btn) {" +
+                        "    btn.click();" +
+                        "  } else {" +
+                        "    window.location.hash = '';" +
+                        "    window.location.reload();" +
+                        "  }" +
+                        "})();";
+                sCachedWebView.evaluateJavascript(js, null);
+            }
+        });
+        rightGroup.addView(btnNewChat);
+
+        // [④ ⬒ 全屏聊天按钮]
+        View btnFullscreen = createHeaderIconButton(ICON_FULLSCREEN, textColor, "全屏打开聊天页面");
+        LinearLayout.LayoutParams fullscreenLp = (LinearLayout.LayoutParams) btnFullscreen.getLayoutParams();
+        fullscreenLp.setMarginStart(dpToPx(4));
+        btnFullscreen.setLayoutParams(fullscreenLp);
+        btnFullscreen.setOnClickListener(v -> {
+            Intent intent = new Intent(this, MainActivity.class);
+            intent.putExtra("open_web", true);
+            intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            startActivity(intent);
+            dismissSheet();
+        });
+        rightGroup.addView(btnFullscreen);
+        headerBar.addView(rightGroup);
+
+        sheetCard.addView(headerBar);
+
+        // 5. 分割线
+        View divider = new View(this);
+        divider.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, dpToPx(1)));
+        divider.setBackgroundColor(lineColor);
+        sheetCard.addView(divider);
+
+        // 6. WebView 主体容器（自适应伸缩，防漏字）
+        webContainer = new FrameLayout(this);
+        LinearLayout.LayoutParams webLp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, 0, 1.0f);
+        webContainer.setLayoutParams(webLp);
+        webContainer.setClipChildren(true);
+        webContainer.setClipToPadding(true);
+
+        progressBar = new ProgressBar(this);
+        FrameLayout.LayoutParams pbLp = new FrameLayout.LayoutParams(dpToPx(36), dpToPx(36));
+        pbLp.gravity = Gravity.CENTER;
+        progressBar.setLayoutParams(pbLp);
+        progressBar.setVisibility(sWebLoaded ? View.GONE : View.VISIBLE);
+        webContainer.addView(progressBar);
+
+        errorHint = new TextView(this);
+        FrameLayout.LayoutParams errLp = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        errLp.gravity = Gravity.CENTER;
+        errorHint.setLayoutParams(errLp);
+        errorHint.setText("正在连接 DSHA 服务…");
+        errorHint.setTextColor(isDarkMode ? Color.parseColor("#94A3B8") : Color.parseColor("#64748B"));
+        errorHint.setTextSize(14);
+        errorHint.setVisibility(View.GONE);
+        webContainer.addView(errorHint);
+
+        sheetCard.addView(webContainer);
+
+        // 7. 键盘底部占位底板（垫在键盘下方，具有与卡片一致的同色毛玻璃底色，绝不漏桌面壁纸）
+        keyboardSpacer = new View(this);
+        keyboardSpacer.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, 0));
+        keyboardSpacer.setBackgroundColor(Color.TRANSPARENT);
+        sheetCard.addView(keyboardSpacer);
+
+        rootOverlay.addView(sheetCard);
+
+        return rootOverlay;
+    }
+
+    private View createHeaderIconButton(int iconType, int iconColor, String contentDescription) {
+        HeaderIconButton btn = new HeaderIconButton(this, iconType, iconColor);
+        LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(dpToPx(36), dpToPx(36));
+        btn.setLayoutParams(lp);
+        btn.setContentDescription(contentDescription);
+        btn.setClickable(true);
+        btn.setFocusable(true);
+
+        // 圆形水波纹反馈
+        GradientDrawable mask = new GradientDrawable();
+        mask.setShape(GradientDrawable.OVAL);
+        mask.setColor(Color.WHITE);
+        RippleDrawable ripple = new RippleDrawable(
+                ColorStateList.valueOf(Color.parseColor("#253D6FD4")), null, mask);
+        btn.setBackground(ripple);
+
+        return btn;
+    }
+
+    /** 4 按钮高精度矢量绘制 View（统一 36x36dp 容器、1.85dp 规范线宽、圆倒角与对称视觉） */
+    private static class HeaderIconButton extends View {
+        private final int iconType;
+        private final Paint paint;
+        private final RectF rectF = new RectF();
+
+        public HeaderIconButton(Context context, int iconType, int color) {
+            super(context);
+            this.iconType = iconType;
+            float density = context.getResources().getDisplayMetrics().density;
+            float strokeWidthPx = 1.85f * density;
+
+            paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+            paint.setStyle(Paint.Style.STROKE);
+            paint.setColor(color);
+            paint.setStrokeWidth(strokeWidthPx);
+            paint.setStrokeCap(Paint.Cap.ROUND);
+            paint.setStrokeJoin(Paint.Join.ROUND);
+        }
+
+        @Override
+        protected void onDraw(Canvas canvas) {
+            super.onDraw(canvas);
+            float w = getWidth();
+            float h = getHeight();
+            float cx = w / 2f;
+            float cy = h / 2f;
+            float dp = getResources().getDisplayMetrics().density;
+
+            switch (iconType) {
+                case ICON_CLOSE: { // ① [ ✕ ] 关闭 (光学收敛，端点半长 6.6dp，避免视觉膨胀)
+                    float s = 6.6f * dp;
+                    canvas.drawLine(cx - s, cy - s, cx + s, cy + s, paint);
+                    canvas.drawLine(cx - s, cy + s, cx + s, cy - s, paint);
+                    break;
+                }
+                case ICON_SETTINGS: { // ② [ >_ 容器控制台 ] (圆角窗口外框 + 内部命令行提示符 > _)
+                    float halfW = 8.5f * dp;
+                    float halfH = 7.0f * dp;
+                    float r = 2.8f * dp;
+                    rectF.set(cx - halfW, cy - halfH, cx + halfW, cy + halfH);
+                    canvas.drawRoundRect(rectF, r, r, paint);
+
+                    // 命令行提示符 >
+                    Path path = new Path();
+                    path.moveTo(cx - 4.5f * dp, cy - 2.8f * dp);
+                    path.lineTo(cx - 1.2f * dp, cy);
+                    path.lineTo(cx - 4.5f * dp, cy + 2.8f * dp);
+                    canvas.drawPath(path, paint);
+
+                    // 光标下划线 _
+                    canvas.drawLine(cx + 0.8f * dp, cy + 2.8f * dp, cx + 4.8f * dp, cy + 2.8f * dp, paint);
+                    break;
+                }
+                case ICON_NEW_CHAT: { // ③ [ 💬➕ ] 新建会话 (圆角对话气泡 + 内部十字加号)
+                    float halfW = 8.2f * dp;
+                    float topH = 7.2f * dp;
+                    float botH = 3.5f * dp;
+                    float r = 2.5f * dp;
+                    rectF.set(cx - halfW, cy - topH, cx + halfW, cy + botH);
+                    canvas.drawRoundRect(rectF, r, r, paint);
+                    // 气泡小尾巴
+                    Path path = new Path();
+                    path.moveTo(cx - 2.8f * dp, cy + botH);
+                    path.lineTo(cx - 6.2f * dp, cy + botH + 4.2f * dp);
+                    path.lineTo(cx - 6.2f * dp, cy + botH);
+                    canvas.drawPath(path, paint);
+                    // 内部加号
+                    float plusR = 2.8f * dp;
+                    float plusCy = cy - 1.8f * dp;
+                    canvas.drawLine(cx, plusCy - plusR, cx, plusCy + plusR, paint);
+                    canvas.drawLine(cx - plusR, plusCy, cx + plusR, plusCy, paint);
+                    break;
+                }
+                case ICON_FULLSCREEN: { // ④ [ ⬒ ] 全屏展开 (顺时针旋转90°后的顶栏+主视口分栏)
+                    float halfW = 8.0f * dp;
+                    float halfH = 8.0f * dp;
+                    float r = 2.8f * dp;
+                    rectF.set(cx - halfW, cy - halfH, cx + halfW, cy + halfH);
+                    canvas.drawRoundRect(rectF, r, r, paint);
+                    // 顶栏水平分割线
+                    float dividerY = cy - 2.8f * dp;
+                    canvas.drawLine(cx - halfW, dividerY, cx + halfW, dividerY, paint);
+                    break;
+                }
+            }
+        }
+    }
+
+    /** 键盘精准监听：单次状态跃迁拉升高度，底部占位块承托输入法，使输入框自然上浮 */
+    private void setupKeyboardObserver() {
+        if (getWindow() == null || getWindow().getDecorView() == null) return;
+        View decorView = getWindow().getDecorView();
+
+        keyboardLayoutListener = () -> {
+            int keyboardHeight = 0;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && decorView.getRootWindowInsets() != null) {
+                keyboardHeight = decorView.getRootWindowInsets().getInsets(WindowInsets.Type.ime()).bottom;
+            }
+            if (keyboardHeight <= 0) {
+                Rect r = new Rect();
+                decorView.getWindowVisibleDisplayFrame(r);
+                int totalHeight = decorView.getRootView().getHeight();
+                if (totalHeight <= 0) totalHeight = screenHeight;
+                int diff = totalHeight - r.bottom;
+                if (diff > dpToPx(100)) {
+                    keyboardHeight = diff;
+                }
+            }
+
+            boolean isKeyboardVisible = keyboardHeight > dpToPx(100);
+
+            if (keyboardSpacer != null) {
+                ViewGroup.LayoutParams lp = keyboardSpacer.getLayoutParams();
+                if (lp != null && lp.height != keyboardHeight) {
+                    lp.height = keyboardHeight;
+                    keyboardSpacer.setLayoutParams(lp);
+                }
+            }
+
+            // 状态跃迁锁：仅在键盘从“隐藏”变为“弹出”的单次边缘跳变时触发拉升，防止每帧循环打断动画
+            if (isKeyboardVisible) {
+                if (!isKeyboardElevated) {
+                    isKeyboardElevated = true;
+                    if (currentHeight <= (int) (screenHeight * 0.52f)) {
+                        animateHeightTo(defaultHeight);
+                    }
+                }
+            } else {
+                isKeyboardElevated = false;
+            }
+        };
+        decorView.getViewTreeObserver().addOnGlobalLayoutListener(keyboardLayoutListener);
+    }
+
+    private void setupGesture() {
+        View.OnTouchListener gestureListener = (v, event) -> {
+            switch (event.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                    initialTouchY = event.getRawY();
+                    initialHeightOnTouch = currentHeight;
+                    return true;
+
+                case MotionEvent.ACTION_MOVE:
+                    float dy = event.getRawY() - initialTouchY; // 下滑 > 0，上滑 < 0
+                    int targetH = (int) (initialHeightOnTouch - dy);
+                    if (targetH > maxHeight) targetH = maxHeight;
+                    if (targetH > 0) {
+                        currentHeight = targetH;
+                        updateCardHeight(targetH);
+                    }
+                    return true;
+
+                case MotionEvent.ACTION_UP:
+                case MotionEvent.ACTION_CANCEL:
+                    // 1. 低于安全下限阈值（< 25%），顺滑向下退出
+                    if (currentHeight < minHeight) {
+                        dismissSheet();
+                    } else {
+                        // 2. 15% 步长阶梯智能吸附停留（35%, 50%, 65%, 80%, 95%）
+                        snapToNearest15PercentStep();
+                    }
+                    return true;
+            }
+            return false;
+        };
+
+        if (sheetCard.getChildCount() > 0) {
+            sheetCard.getChildAt(0).setOnTouchListener(gestureListener); // dragArea
+        }
+        if (sheetCard.getChildCount() > 1) {
+            sheetCard.getChildAt(1).setOnTouchListener(gestureListener); // headerBar
+        }
+    }
+
+    private void updateCardHeight(int height) {
+        if (sheetCard != null) {
+            ViewGroup.LayoutParams lp = sheetCard.getLayoutParams();
+            if (lp != null && lp.height != height) {
+                lp.height = height;
+                sheetCard.setLayoutParams(lp);
+            }
+        }
+    }
+
+    /** 15% 阶梯智能多档吸附算法（35%, 50%, 65%, 80%, 95%） */
+    private void snapToNearest15PercentStep() {
+        float[] steps = {0.35f, 0.50f, 0.65f, 0.80f, 0.95f};
+        float currentRatio = (float) currentHeight / (float) screenHeight;
+
+        float closestRatio = steps[0];
+        float minDiff = Math.abs(currentRatio - steps[0]);
+
+        for (int i = 1; i < steps.length; i++) {
+            float diff = Math.abs(currentRatio - steps[i]);
+            if (diff < minDiff) {
+                minDiff = diff;
+                closestRatio = steps[i];
+            }
+        }
+
+        int targetH = (int) (screenHeight * closestRatio);
+        animateHeightTo(targetH);
+    }
+
+    private void animateHeightTo(int targetH) {
+        int startH = currentHeight;
+        if (startH == targetH) return;
+
+        if (heightAnimator != null && heightAnimator.isRunning()) {
+            heightAnimator.cancel();
+        }
+
+        heightAnimator = ValueAnimator.ofInt(startH, targetH);
+        heightAnimator.setDuration(180);
+        heightAnimator.setInterpolator(new DecelerateInterpolator());
+        heightAnimator.addUpdateListener(animation -> {
+            currentHeight = (int) animation.getAnimatedValue();
+            updateCardHeight(currentHeight);
+        });
+        heightAnimator.start();
+    }
+
+    /** 挂载常驻单例 WebView，实现 100% 零转圈秒开、1:1 原生字体与透明毛玻璃透光 */
+    private void attachChatWeb() {
+        if (sCachedWebView == null) {
+            sCachedWebView = new WebView(getApplicationContext());
+            WebSettings ws = sCachedWebView.getSettings();
+            ws.setJavaScriptEnabled(true);
+            ws.setDomStorageEnabled(true);
+            ws.setDatabaseEnabled(true);
+            ws.setSupportMultipleWindows(false);
+            ws.setUseWideViewPort(true);
+            // 移除 setLoadWithOverviewMode(true)，设置 100% 原始字体比例
+            ws.setLoadWithOverviewMode(false);
+            ws.setTextZoom(100);
+            ws.setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
+            ws.setAllowFileAccess(false);
+            ws.setAllowContentAccess(false);
+            ws.setCacheMode(WebSettings.LOAD_DEFAULT);
+
+            // 禁用系统自动算法反色
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                try {
+                    ws.setForceDark(WebSettings.FORCE_DARK_OFF);
+                } catch (Throwable ignored) {}
+            }
+            if (Build.VERSION.SDK_INT >= 33) {
+                try {
+                    ws.setAlgorithmicDarkeningAllowed(false);
+                } catch (Throwable ignored) {}
+            }
+
+            sCachedWebView.setBackgroundColor(Color.TRANSPARENT);
+
+            boolean desktop = getSharedPreferences("deepseekharness", Context.MODE_PRIVATE)
+                    .getBoolean("desktop_mode", false);
+            if (desktop) {
+                ws.setUserAgentString("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                        + "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36");
+            }
+
+            sCachedWebView.setWebViewClient(new WebViewClient() {
+                @Override
+                public void onPageFinished(WebView view, String url) {
+                    super.onPageFinished(view, url);
+                    sWebLoaded = true;
+                    if (progressBar != null) progressBar.setVisibility(View.GONE);
+                    // 彻底覆写 DSH 前端 CSS 变量与 DOM 背景，消除纯黑实心色，透出半透明毛玻璃卡片
+                    injectTransparentBackground(view);
+                }
+
+                @Override
+                public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+                    super.onReceivedError(view, request, error);
+                    if (request != null && request.isForMainFrame() && errorHint != null) {
+                        if (progressBar != null) progressBar.setVisibility(View.GONE);
+                        errorHint.setVisibility(View.VISIBLE);
+                        errorHint.setText("DSHA 服务未就绪，请先在控制台启动");
+                    }
+                }
+            });
+
+            sCachedWebView.setWebChromeClient(new WebChromeClient());
+
+            String base = "http://127.0.0.1:" + (controller != null ? controller.getPort() : "3080") + "/";
+            String token = HttpShellService.currentToken();
+            String url = token.isEmpty() ? base : base + "?dsha_t=" + Uri.encode(token);
+            sCachedWebView.loadUrl(url);
+        } else {
+            if (sCachedWebView.getParent() instanceof ViewGroup) {
+                ((ViewGroup) sCachedWebView.getParent()).removeView(sCachedWebView);
+            }
+            if (progressBar != null) {
+                progressBar.setVisibility(sWebLoaded ? View.GONE : View.VISIBLE);
+            }
+            injectTransparentBackground(sCachedWebView);
+        }
+
+        webContainer.addView(sCachedWebView, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+    }
+
+    /** 彻底覆写前端背景 CSS 变量，确保背景 100% 透明透光 */
+    private void injectTransparentBackground(WebView view) {
+        if (view == null) return;
+        try {
+            String js = "(function() {" +
+                    "  var css = `\n" +
+                    "    html, body, #root, [data-ds-dark-theme], main, .dsh-layout-root, div[class*='_root_'], div[class*='_wrap_'], div[class*='_container_'] {\n" +
+                    "      background: transparent !important;\n" +
+                    "      background-color: transparent !important;\n" +
+                    "    }\n" +
+                    "    :root, .dark, [data-ds-dark-theme] {\n" +
+                    "      --dsw-alias-bg-base: transparent !important;\n" +
+                    "      --dsw-alias-bg-layer-1: transparent !important;\n" +
+                    "      --dsw-alias-bg-layer-2: rgba(255, 255, 255, 0.05) !important;\n" +
+                    "      --dsw-specific-sidebar-fill: transparent !important;\n" +
+                    "    }\n" +
+                    "  `;\n" +
+                    "  var style = document.getElementById('dsh-transparent-style');\n" +
+                    "  if (!style) {\n" +
+                    "    style = document.createElement('style');\n" +
+                    "    style.id = 'dsh-transparent-style';\n" +
+                    "    document.head.appendChild(style);\n" +
+                    "  }\n" +
+                    "  style.innerHTML = css;\n" +
+                    "  if (document.documentElement) document.documentElement.style.backgroundColor = 'transparent';\n" +
+                    "  if (document.body) document.body.style.backgroundColor = 'transparent';\n" +
+                    "})();";
+            view.evaluateJavascript(js, null);
+        } catch (Throwable ignored) {}
+    }
+
+    /** 从底部顺滑滑入展开（屏幕外静默就绪，绝不闪屏变形） */
+    private void animateIn() {
+        isDismissing = false;
+        if (sheetCard != null) {
+            // 如果上次处于低位 (<=50%)，在屏幕外先设为不可见并修改高度
+            if (currentHeight <= (int) (screenHeight * 0.52f)) {
+                currentHeight = defaultHeight;
+                updateCardHeight(defaultHeight);
+            }
+            sheetCard.setVisibility(View.INVISIBLE);
+            sheetCard.setTranslationY(screenHeight > 0 ? screenHeight : 2500);
+
+            sheetCard.post(() -> {
+                sheetCard.setTranslationY(sheetCard.getHeight() > 0 ? sheetCard.getHeight() : defaultHeight);
+                sheetCard.setVisibility(View.VISIBLE);
+                sheetCard.animate()
+                        .translationY(0)
+                        .setDuration(220)
+                        .setInterpolator(new DecelerateInterpolator())
+                        .setListener(null)
+                        .start();
+            });
+        }
+    }
+
+    /** 顺滑向下平移退出弹层并转入后台保活（moveTaskToBack，退出时绝不碰高度） */
+    private void dismissSheet() {
+        if (isDismissing) return;
+        isDismissing = true;
+
+        // 退出前顺带隐藏键盘
+        try {
+            InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (imm != null && getCurrentFocus() != null) {
+                imm.hideSoftInputFromWindow(getCurrentFocus().getWindowToken(), 0);
+            }
+        } catch (Throwable ignored) {}
+
+        if (sheetCard != null) {
+            sheetCard.animate()
+                    .translationY(sheetCard.getHeight() + dpToPx(30))
+                    .setDuration(180)
+                    .setInterpolator(new DecelerateInterpolator())
+                    .setListener(new AnimatorListenerAdapter() {
+                        @Override
+                        public void onAnimationEnd(Animator animation) {
+                            moveTaskToBack(true);
+                            overridePendingTransition(0, 0);
+                            isDismissing = false;
+                        }
+                    })
+                    .start();
+        } else {
+            moveTaskToBack(true);
+            overridePendingTransition(0, 0);
+            isDismissing = false;
+        }
+    }
+
+    private int dpToPx(int dp) {
+        return (int) (dp * getResources().getDisplayMetrics().density + 0.5f);
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (sCachedWebView != null && sCachedWebView.canGoBack()) {
+            sCachedWebView.goBack();
+        } else {
+            dismissSheet();
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (keyboardLayoutListener != null && getWindow() != null && getWindow().getDecorView() != null) {
+            getWindow().getDecorView().getViewTreeObserver().removeOnGlobalLayoutListener(keyboardLayoutListener);
+        }
+        super.onDestroy();
+        if (sCachedWebView != null && sCachedWebView.getParent() == webContainer) {
+            webContainer.removeView(sCachedWebView);
+        }
+    }
+}

--- a/app/src/main/java/com/deepseekharness/app/TaskNotifier.java
+++ b/app/src/main/java/com/deepseekharness/app/TaskNotifier.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class TaskNotifier {
 
-    public static final String CHANNEL_ID = "dsh_task_channel";
+    public static final String CHANNEL_ID = Constants.CHANNEL_TASK_RESULT;
     private static final int NOTIF_ID = 2002;
     private static final long POLL_MS = 4000;
     private static final long IDLE_MS = 90000;      // 静默 90 秒判定完成（容忍 agent 长思考）
@@ -88,28 +88,43 @@ public class TaskNotifier {
     }
 
     private void notifyDone() {
-        Intent intent = new Intent(ctx, MainActivity.class)
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm != null) {
+            nm.cancel(Constants.NOTIF_TASK_RUNNING);
+        }
+
+        Intent intent = new Intent(ctx, QuickChatSheetActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         PendingIntent pi = PendingIntent.getActivity(ctx, 0, intent,
                 PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+        // 点击「💬 继续对话」直接从屏幕底部唤起抽屉弹层
+        Intent actionIntent = new Intent(ctx, QuickChatSheetActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent actionPi = PendingIntent.getActivity(ctx, 26, actionIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        NotificationCompat.Action replyAction = new NotificationCompat.Action.Builder(
+                R.drawable.ic_launch, "💬 继续对话", actionPi)
+                .build();
+
         Notification n = new NotificationCompat.Builder(ctx, CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_launch)
                 .setContentTitle("DSHA · 任务完成")
                 .setContentText("智能体已结束任务，点击查看结果")
                 .setContentIntent(pi)
+                .addAction(replyAction)
                 .setAutoCancel(true)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .build();
-        NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
         if (nm != null) nm.notify(NOTIF_ID, n);
     }
 
     private void createChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel ch = new NotificationChannel(
-                    CHANNEL_ID, "任务完成提醒",
+                    CHANNEL_ID, "任务结果与交互",
                     NotificationManager.IMPORTANCE_HIGH);
-            ch.setDescription("智能体任务完成时通知");
+            ch.setDescription("智能体任务完成、异常结束或终止时的结果通知");
             NotificationManager nm = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
             if (nm != null) nm.createNotificationChannel(ch);
         }

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -29,5 +29,24 @@
 
         <item name="alertDialogTheme">@style/Dialog.DSHA.Alert</item>
         <item name="materialAlertDialogTheme">@style/Dialog.DSHA.Material</item>
+
+        <!-- 必须和 values/themes.xml 保持一致：Material3 会把 <Button> 膨胀成
+             MaterialButton 并用 backgroundTint=colorPrimary 填充，忽略
+             android:background。深色模式下 primary 是浅蓝 #7DA7F4，
+             配 text_secondary #A6B0C3 对比度只有约 1.3:1 —— 就是用户看到的
+             「浅蓝底白字看不清」。上一版只改了 day 那份，深色模式毫无变化。 -->
+        <item name="materialButtonStyle">@style/Widget.DSHA.Button</item>
+    </style>
+
+    <!-- 快捷抽屉弹层专用全屏透明主题（深色模式） -->
+    <style name="Theme.DeepseekHarness.SheetTransparent" parent="Theme.DeepseekHarness">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackground">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowContentOverlay">@null</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -37,6 +37,19 @@
              materialAlertDialogTheme 管 MaterialAlertDialogBuilder。 -->
         <item name="alertDialogTheme">@style/Dialog.DSHA.Alert</item>
         <item name="materialAlertDialogTheme">@style/Dialog.DSHA.Material</item>
+
+        <!-- 关键：Material3 主题会把布局里的 <Button> 自动膨胀成 MaterialButton，
+             而 MaterialButton 的默认样式是 filled —— 它用 backgroundTint=colorPrimary
+             填充背景，**直接忽略 android:background**。
+             结果在深色模式下就是「浅蓝底（primary #7DA7F4）+ 浅灰字
+             （text_secondary #A6B0C3）」，对比度约 1.3:1，根本看不清写了什么。
+             用户实测反馈的正是「设置里 ADB 设备通道的所有按钮」。
+
+             改成 Widget.DSHA.Button：backgroundTint 置空，让各布局自己声明的
+             bg_btn / bg_btn_primary 真正生效。这些 drawable 本身已经带 ripple
+             和禁用态，所以不损失 Material 的交互反馈。
+             一处覆盖，全项目 12+ 个 <Button> 一起修好。 -->
+        <item name="materialButtonStyle">@style/Widget.DSHA.Button</item>
     </style>
 
     <!-- appcompat / framework AlertDialog：必须是完整 Dialog 主题（不能给 Overlay） -->
@@ -60,5 +73,17 @@
     <style name="Shape.DSHA.Dialog" parent="">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">@dimen/radius_card</item>
+    </style>
+
+    <!-- 快捷抽屉弹层专用全屏透明主题（无黑边、无白状态栏、左右 100% 满屏无留白） -->
+    <style name="Theme.DeepseekHarness.SheetTransparent" parent="Theme.DeepseekHarness">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackground">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowContentOverlay">@null</item>
     </style>
 </resources>


### PR DESCRIPTION
### B3. 增加通知交互与 Activity快捷抽屉弹层
点击通知栏常驻通知或者交互按钮即可调出

通知交互升级为全局快捷悬浮抽屉弹层**（取代原本局限狭窄的通知栏 `RemoteInput` 打字输入框）：

#### 特性与技术规范：
1. **物理边缘 100% 满屏贴合**：
   - 摆脱 Dialog 边距约束：配置 `Theme.DeepseekHarness.SheetTransparent`（`windowIsTranslucent=true`、`windowIsFloating=false`、`statusBarColor=@android:color/transparent`）；
   - 消除系统浮动边框，左右两侧贴紧手机物理屏幕边缘**，呈现宽屏视觉。
2. **15% 多档阶梯吸附停靠（35% ~ 95%）**：
   - 内置基于 `screenHeight` 的 15% 步长阶梯锚点算法（**35%、50%、65%、80%、95%**）；
   - 默认初始高度为 **78%**，可拉升至 **95%**；
   - 拖拽松手时自动吸附到最近的 15% 档位；仅当在半屏继续用力向下拉动、高度低于安全下限（`< 25%`）时才触发向下滑出退出，**杜绝从全屏拉回半屏时误退出**。
3. **毛玻璃半透明质感与 CSS 变量透光**：
   - 绘制 24dp 顶部大圆角与 `#EBF5F8FC`（浅色）/ `#EB161B24`（深色）半透明背景与细微描边；
   - 页面加载时注入动态 CSS 样式，强制覆写 DSH 前端的 `--dsw-alias-bg-base`、`--dsw-alias-bg-layer-1`、`--dsw-specific-sidebar-fill` 为 `transparent !important`；
   - 显式关闭 `FORCE_DARK` 与 `setAlgorithmicDarkeningAllowed(false)`，**保持 DSHA 原貌，透出底层桌面壁纸与应用**。
4. **顶栏 4 按钮统一规格与创建新会话功能**：
   - **规格对齐**：4 个按钮一律锁定为 **36dp × 36dp** 外层触摸区与 36dp 正圆水波纹反馈，内部图形严格基于 24dp 视口与 1.85dp圆倒角绘制，尺寸补偿；
   - **对称绝对居中**：左侧 2 个按钮（`[✕]` + `[>_]`）与右侧 2 个按钮（`[➕]` + `[⬒]`）对称（各占用 76dp），中间“DSHA 对话”标题在屏幕正中央居中；
   - **4 按钮功能**：
     - **① `[ ✕ ]` 关闭：退出并转入后台保活（`moveTaskToBack`）；
     - **② `[ >_ ]` 容器终端控制台**：圆角窗口外框与命令行提示符 `>_`， `go_home=true` 一键唤醒并跳转至 `MainActivity` 容器后台主界面（自动退出全屏 Web，固定展示包含启动/终端/市场/设置的主页）；
     - **③ `[ 💬➕ ]` 开启新对话**：圆角气泡内嵌十字加号，通过 DOM 事件触发 DSH 前端内置新会话广播或路由重置，清空输入框并开启全新对话流；
     - **④ `[ ⬒ ]` 全屏聊天**：进入主 App 完整全屏对话页（彻底避开与网页内展开侧边栏图标的视觉撞车）。
5. **修复1：键盘弹出画面错位修复**：
   - **卡片外壳**：卡片顶边由物理坐标固定，Window 采用 `SOFT_INPUT_ADJUST_NOTHING`，键盘弹出时顶栏、关闭与设置按钮不被顶出屏幕；
   - **低位自动拉高升档**：当卡片处于 $\le 50\%$ 低位时，点击输入框弹出键盘瞬间，通过单次状态跃迁锁平滑触发 180ms 减速动画将卡片拉升至 **78% 默认舒适高度**，解决低档位打字视角问题；
   - **贴底同色毛玻璃底板**：卡片底板延伸覆盖到屏幕物理最底端，键盘覆盖在卡片上方，**修复键盘使用透明背景时背板画面异常**；
   - **网页输入框自适应上浮**：内部 `webContainer` 响应输入法高度，网页底部的输入框自动精准吸附在输入法正上方。
6. **弹层配置独立、防误跳桌面**：
   - `AndroidManifest.xml` 中将弹层配置独立亲和性 `taskAffinity="com.dsh.client.quick_sheet"`；
   - 与主 App 的 Launcher 任务栈在系统层级隔离，**从手机桌面点击 DSHA 图标固定打开主 App，不再误跳弹层**。
7. **内存单例保活秒开与静默就绪重置**：
   - 采用内存静态 `WebView` 常驻缓存，1:1 精准还原字体（移除 OverviewMode，设置 textZoom 100）；
   - 用户下滑或点击 ✕ 退出时，平滑滑出后调用 `moveTaskToBack(true)` 挂起保活，退出时完全不碰高度，消除退出闪烁；
   - 若在 $\le 50\%$ 低位离开，下次呼出在屏幕外静默将高度重置为 78% 后再滑入屏幕，**会话状态不丢、输入框草稿不丢、无须重新加载**。（问题，弹层不会自动刷新，如遇bug需要手动关闭或者重启app）

#### 命令行直接调出方法：没有设置按键监听，可调用shotx等工具绑定按钮
```bash
# 1. DSHA 容器内执行（推荐）：
/root/dsh-bin/adb-shell "am start -n com.dsh.client/com.deepseekharness.app.QuickChatSheetActivity"

# 2. Android 设备终端（Termux / Shizuku / ADB）：
am start -n com.dsh.client/com.deepseekharness.app.QuickChatSheetActivity
```

### B4. 点通知直达抽屉弹层

原先点通知只能全屏切到 App 首页或全屏 WebView。现已全链路统一收拢至抽屉弹层：

- `HarnessService.java`（常驻保活 1001）/ `TaskNotifier.java`（任务完成 2002）/ `HttpShellService.java`（实时运行 2003）/ `ConfirmReceiver.java`（任务终止 2004）的所有通知点击主体均统一指向 `QuickChatSheetActivity`；
- 配置 `FLAG_ACTIVITY_REORDER_TO_FRONT | FLAG_ACTIVITY_SINGLE_TOP`，复用后台常驻实例秒开；
- 弹层顶部配备 `[>_ 容器控制台]` 与 `[◫ 全屏聊天]` 按钮，可一键转入全屏。

| 通知类型 | 触发场景 | 点击行为 |
| :--- | :--- | :--- |
| **常驻保活通知** (1001) | DSHA 后台服务运行中 | 点击通知主体直接从屏幕底部顺滑唤起抽屉弹层 |
| **任务实时运行通知** (2003) | 智能体执行多步骤自动化任务中 | 点击通知主体直达抽屉弹层，带 `[🛑 停止任务]` 动作按钮 |
| **任务完成通知** (2002) | 智能体完成单轮/多轮任务 | 点击通知主体或点击 `[💬 继续对话]` 按钮，直接唤起抽屉弹层 |
| **任务终止通知** (2004) | 用户紧急制动或外部异常中断 | 点击通知主体或点击 `[💬 重新开始]` 按钮，直接唤起抽屉弹层 |

尚未完成功能：呼出弹层没有返回当前任务对话功能，默认加载退出时遗留界面

https://github.com/user-attachments/assets/4cc31cc4-05c4-4028-aeec-5e3c5a44f105




